### PR TITLE
FEAT: CampaignInfluencerProduct에 status 필드 추가

### DIFF
--- a/apps/api/src/database/migration/1766300000000-add-status-to-campaign-influencer-product.ts
+++ b/apps/api/src/database/migration/1766300000000-add-status-to-campaign-influencer-product.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddStatusToCampaignInfluencerProduct1766300000000
+  implements MigrationInterface
+{
+  name = 'AddStatusToCampaignInfluencerProduct1766300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // campaign_influencer_product 테이블에 status 컬럼 추가
+    // 기존 campaign_status_enum 재사용 (VISIBLE, HIDDEN, SOLD_OUT)
+    await queryRunner.query(`
+      ALTER TABLE "campaign_influencer_product"
+      ADD COLUMN "status" "public"."campaign_status_enum" NOT NULL DEFAULT 'VISIBLE'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // status 컬럼 제거
+    await queryRunner.query(`
+      ALTER TABLE "campaign_influencer_product"
+      DROP COLUMN "status"
+    `);
+  }
+}

--- a/apps/api/src/module/backoffice/campaign/campaign.schema.ts
+++ b/apps/api/src/module/backoffice/campaign/campaign.schema.ts
@@ -65,6 +65,7 @@ export const campaignInfluencerHotelOptionInputSchema = z.object({
 // CampaignInfluencerProduct Input Schema - 인플루언서별 상품 설정
 export const campaignInfluencerProductInputSchema = z.object({
   productId: z.number(),
+  status: campaignStatusEnumSchema.default('VISIBLE'),
   useCustomCommission: z.boolean().default(false),
   hotelOptions: z.array(campaignInfluencerHotelOptionInputSchema).default([]),
 });
@@ -141,6 +142,7 @@ export const campaignInfluencerHotelOptionResponseSchema = z.object({
 export const campaignInfluencerProductResponseSchema = z.object({
   campaignInfluencerProductId: z.number(),
   productId: z.number(),
+  status: campaignStatusEnumSchema,
   useCustomCommission: z.boolean(),
   hotelOptions: z.array(campaignInfluencerHotelOptionResponseSchema),
 });

--- a/apps/api/src/module/backoffice/campaign/campaign.service.ts
+++ b/apps/api/src/module/backoffice/campaign/campaign.service.ts
@@ -296,6 +296,7 @@ export class CampaignService {
           this.repositoryProvider.CampaignInfluencerProductRepository.create({
             campaignInfluencerId,
             productId: productInput.productId,
+            status: productInput.status,
             useCustomCommission: productInput.useCustomCommission,
           });
 

--- a/apps/api/src/module/backoffice/domain/campaign-influencer-product.entity.ts
+++ b/apps/api/src/module/backoffice/domain/campaign-influencer-product.entity.ts
@@ -13,6 +13,11 @@ import { CampaignInfluencerEntity } from '@src/module/backoffice/domain/campaign
 import { ProductEntity } from '@src/module/backoffice/domain/product/product.entity';
 import { TransactionService } from '@src/module/shared/transaction/transaction.service';
 import { getEntityManager } from '@src/database/datasources';
+import {
+  CAMPAIGN_STATUS_ENUM_VALUE,
+  CampaignStatusEnum,
+  type CampaignStatusEnumType,
+} from '@src/module/backoffice/campaign/campaign.schema';
 
 // Forward declaration for circular reference
 import type {
@@ -24,6 +29,7 @@ import type {
 export interface CampaignInfluencerProductResponse {
   campaignInfluencerProductId: number;
   productId: number;
+  status: CampaignStatusEnumType;
   useCustomCommission: boolean;
   hotelOptions: CampaignInfluencerHotelOptionResponse[];
 }
@@ -53,6 +59,14 @@ export class CampaignInfluencerProductEntity extends BaseEntity {
   @JoinColumn({ name: 'product_id' })
   product: ProductEntity;
 
+  // 판매 페이지 상태 (VISIBLE, HIDDEN, SOLD_OUT)
+  @Column({
+    type: 'enum',
+    enum: CAMPAIGN_STATUS_ENUM_VALUE,
+    default: CampaignStatusEnum.VISIBLE,
+  })
+  status: CampaignStatusEnumType;
+
   // 별도 수수료 사용 여부
   @Column({ name: 'use_custom_commission', type: 'boolean', default: false })
   useCustomCommission: boolean;
@@ -69,6 +83,7 @@ export class CampaignInfluencerProductEntity extends BaseEntity {
     return {
       campaignInfluencerProductId: this.id,
       productId: this.productId,
+      status: this.status,
       useCustomCommission: this.useCustomCommission,
       hotelOptions: (this.hotelOptions ?? []).map(option =>
         option.toResponse()

--- a/packages/api-types/src/server.ts
+++ b/packages/api-types/src/server.ts
@@ -995,6 +995,11 @@ const appRouter = t.router({
         products: z.array(z.object({
           campaignInfluencerProductId: z.number(),
           productId: z.number(),
+          status: z.enum([
+            'VISIBLE',
+            'HIDDEN',
+            'SOLD_OUT',
+          ] as const),
           useCustomCommission: z.boolean(),
           hotelOptions: z.array(z.object({
             campaignInfluencerHotelOptionId: z.number(),
@@ -1070,6 +1075,11 @@ const appRouter = t.router({
         products: z.array(z.object({
           campaignInfluencerProductId: z.number(),
           productId: z.number(),
+          status: z.enum([
+            'VISIBLE',
+            'HIDDEN',
+            'SOLD_OUT',
+          ] as const),
           useCustomCommission: z.boolean(),
           hotelOptions: z.array(z.object({
             campaignInfluencerHotelOptionId: z.number(),
@@ -1147,6 +1157,11 @@ const appRouter = t.router({
         products: z.array(z.object({
           campaignInfluencerProductId: z.number(),
           productId: z.number(),
+          status: z.enum([
+            'VISIBLE',
+            'HIDDEN',
+            'SOLD_OUT',
+          ] as const),
           useCustomCommission: z.boolean(),
           hotelOptions: z.array(z.object({
             campaignInfluencerHotelOptionId: z.number(),

--- a/packages/api-types/src/types/campaign.ts
+++ b/packages/api-types/src/types/campaign.ts
@@ -27,6 +27,7 @@ export const campaignHotelOptionInputSchema = z.object({
 // CampaignInfluencerProduct Input Schema
 export const campaignInfluencerProductInputSchema = z.object({
   productId: z.number(),
+  status: campaignStatusEnumSchema.default('VISIBLE'),
   useCustomCommission: z.boolean().default(false),
   hotelOptions: z.array(campaignHotelOptionInputSchema).default([]),
 });


### PR DESCRIPTION
## Summary
- 캠페인-인플루언서-상품 조합별로 판매페이지 상태를 독립적으로 관리할 수 있도록 status 필드 추가
- 기존 CAMPAIGN_STATUS_ENUM (VISIBLE/HIDDEN/SOLD_OUT) 재사용
- 캠페인/인플루언서 상태와 별개로 개별 상품의 판매 상태를 제어 가능

## 변경사항

### API (apps/api)
| 파일 | 변경 내용 |
|------|-----------|
| `campaign-influencer-product.entity.ts` | status 컬럼 추가 |
| `campaign.schema.ts` | input/response 스키마에 status 추가 |
| `campaign.service.ts` | create 시 status 저장 |
| `1766300000000-add-status-...ts` | Migration 추가 |

### api-types (packages/api-types)
| 파일 | 변경 내용 |
|------|-----------|
| `types/campaign.ts` | campaignInfluencerProductInputSchema에 status 추가 |
| `server.ts` | import 및 response 스키마 동기화 |

## Test plan
- [ ] Migration 실행 확인 (`yarn migration:run`)
- [ ] 캠페인 생성 시 인플루언서 상품에 status 전달 확인
- [ ] 캠페인 조회 시 인플루언서 상품의 status 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)