### PR TITLE
FEAT: 캠페인 다른 상품 조회 API 및 Custom Repository 추가

### DIFF
--- a/apps/api/src/module/backoffice/domain/campaign-influencer-product.entity.ts
+++ b/apps/api/src/module/backoffice/domain/campaign-influencer-product.entity.ts
@@ -95,15 +95,6 @@ export class CampaignInfluencerProductEntity extends BaseEntity {
 
 export const getCampaignInfluencerProductRepository = (
   source?: TransactionService | EntityManager
-) => getEntityManager(source).getRepository(CampaignInfluencerProductEntity);
-
-/**
- * CampaignInfluencerProduct Custom Repository
- *
- * 공통 조회 로직을 제공합니다.
- */
-export const getCampaignInfluencerProductCustomRepository = (
-  source?: TransactionService | EntityManager
 ) => {
   const repo = getEntityManager(source).getRepository(
     CampaignInfluencerProductEntity

--- a/apps/api/src/module/backoffice/domain/campaign-influencer-product.entity.ts
+++ b/apps/api/src/module/backoffice/domain/campaign-influencer-product.entity.ts
@@ -36,6 +36,17 @@ export interface CampaignInfluencerProductResponse {
 }
 
 /**
+ * 상품 요약 정보 (Shop 페이지용)
+ */
+export interface ProductSummary {
+  id: number; // saleId (CampaignInfluencerProduct.id)
+  thumbnailUrl: string | null;
+  name: string;
+  originalPrice: number;
+  price: number;
+}
+
+/**
  * CampaignInfluencerProduct Entity
  *
  * 인플루언서별 상품 설정을 관리합니다.
@@ -89,6 +100,21 @@ export class CampaignInfluencerProductEntity extends BaseEntity {
       hotelOptions: (this.hotelOptions ?? []).map(option =>
         option.toResponse()
       ),
+    };
+  }
+
+  /**
+   * 상품 요약 정보 변환 (Shop 페이지용)
+   *
+   * product relation이 로드되어 있어야 합니다.
+   */
+  toProductSummary(): ProductSummary {
+    return {
+      id: this.id,
+      thumbnailUrl: this.product.thumbnailUrls?.[0] ?? null,
+      name: this.product.name,
+      originalPrice: this.product.originalPrice,
+      price: this.product.price,
     };
   }
 }

--- a/apps/api/src/module/backoffice/domain/campaign-influencer-product.entity.ts
+++ b/apps/api/src/module/backoffice/domain/campaign-influencer-product.entity.ts
@@ -149,34 +149,31 @@ export class CampaignInfluencerProductEntity extends BaseEntity {
 
 export const getCampaignInfluencerProductRepository = (
   source?: TransactionService | EntityManager
-) => {
-  const repo = getEntityManager(source).getRepository(
-    CampaignInfluencerProductEntity
-  );
+) =>
+  getEntityManager(source)
+    .getRepository(CampaignInfluencerProductEntity)
+    .extend({
+      /**
+       * saleId로 판매 상품 조회 (없으면 NotFoundException)
+       *
+       * @param saleId CampaignInfluencerProduct.id
+       * @param relations 조회할 relation 목록
+       */
+      async findBySaleIdOrFail(
+        saleId: number,
+        relations: string[] = []
+      ): Promise<CampaignInfluencerProductEntity> {
+        const product = await this.findOne({
+          where: { id: saleId },
+          relations,
+        });
 
-  return Object.assign(repo, {
-    /**
-     * saleId로 판매 상품 조회 (없으면 NotFoundException)
-     *
-     * @param saleId CampaignInfluencerProduct.id
-     * @param relations 조회할 relation 목록
-     */
-    async findBySaleIdOrFail(
-      saleId: number,
-      relations: string[] = []
-    ): Promise<CampaignInfluencerProductEntity> {
-      const product = await repo.findOne({
-        where: { id: saleId },
-        relations,
-      });
+        if (!product) {
+          throw new NotFoundException(
+            `판매 상품을 찾을 수 없습니다 (ID: ${saleId})`
+          );
+        }
 
-      if (!product) {
-        throw new NotFoundException(
-          `판매 상품을 찾을 수 없습니다 (ID: ${saleId})`
-        );
-      }
-
-      return product;
-    },
-  });
-};
+        return product;
+      },
+    });

--- a/apps/api/src/module/backoffice/domain/campaign-influencer-product.entity.ts
+++ b/apps/api/src/module/backoffice/domain/campaign-influencer-product.entity.ts
@@ -36,12 +36,24 @@ export interface CampaignInfluencerProductResponse {
 }
 
 /**
- * 상품 요약 정보 (Shop 페이지용)
+ * 상품 요약 정보 (Shop 상품 상세용)
  */
 export interface ProductSummary {
   id: number; // saleId (CampaignInfluencerProduct.id)
   thumbnailUrl: string | null;
   name: string;
+  originalPrice: number;
+  price: number;
+}
+
+/**
+ * Shop 상품 정보 (인플루언서 페이지용)
+ */
+export interface ShopProductInfo {
+  id: number; // product.id
+  saleId: number; // CampaignInfluencerProduct.id
+  name: string;
+  thumbnail: string | null;
   originalPrice: number;
   price: number;
 }
@@ -104,7 +116,7 @@ export class CampaignInfluencerProductEntity extends BaseEntity {
   }
 
   /**
-   * 상품 요약 정보 변환 (Shop 페이지용)
+   * 상품 요약 정보 변환 (Shop 상품 상세용)
    *
    * product relation이 로드되어 있어야 합니다.
    */
@@ -113,6 +125,22 @@ export class CampaignInfluencerProductEntity extends BaseEntity {
       id: this.id,
       thumbnailUrl: this.product.thumbnailUrls?.[0] ?? null,
       name: this.product.name,
+      originalPrice: this.product.originalPrice,
+      price: this.product.price,
+    };
+  }
+
+  /**
+   * Shop 상품 정보 변환 (인플루언서 페이지용)
+   *
+   * product relation이 로드되어 있어야 합니다.
+   */
+  toShopProduct(): ShopProductInfo {
+    return {
+      id: this.product.id,
+      saleId: this.id,
+      name: this.product.name,
+      thumbnail: this.product.thumbnailUrls?.[0] ?? null,
       originalPrice: this.product.originalPrice,
       price: this.product.price,
     };

--- a/apps/api/src/module/backoffice/domain/campaign-influencer-product.entity.ts
+++ b/apps/api/src/module/backoffice/domain/campaign-influencer-product.entity.ts
@@ -8,6 +8,7 @@ import {
   Unique,
   OneToMany,
 } from 'typeorm';
+import { NotFoundException } from '@nestjs/common';
 import { BaseEntity } from '@src/module/backoffice/domain/base.entity';
 import { CampaignInfluencerEntity } from '@src/module/backoffice/domain/campaign-influencer.entity';
 import { ProductEntity } from '@src/module/backoffice/domain/product/product.entity';
@@ -95,3 +96,44 @@ export class CampaignInfluencerProductEntity extends BaseEntity {
 export const getCampaignInfluencerProductRepository = (
   source?: TransactionService | EntityManager
 ) => getEntityManager(source).getRepository(CampaignInfluencerProductEntity);
+
+/**
+ * CampaignInfluencerProduct Custom Repository
+ *
+ * 공통 조회 로직을 제공합니다.
+ */
+export const getCampaignInfluencerProductCustomRepository = (
+  source?: TransactionService | EntityManager
+) => {
+  const repo = getEntityManager(source).getRepository(
+    CampaignInfluencerProductEntity
+  );
+
+  return {
+    ...repo,
+
+    /**
+     * saleId로 판매 상품 조회 (없으면 NotFoundException)
+     *
+     * @param saleId CampaignInfluencerProduct.id
+     * @param relations 조회할 relation 목록
+     */
+    async findBySaleIdOrFail(
+      saleId: number,
+      relations: string[] = []
+    ): Promise<CampaignInfluencerProductEntity> {
+      const product = await repo.findOne({
+        where: { id: saleId },
+        relations,
+      });
+
+      if (!product) {
+        throw new NotFoundException(
+          `판매 상품을 찾을 수 없습니다 (ID: ${saleId})`
+        );
+      }
+
+      return product;
+    },
+  };
+};

--- a/apps/api/src/module/backoffice/domain/campaign-influencer-product.entity.ts
+++ b/apps/api/src/module/backoffice/domain/campaign-influencer-product.entity.ts
@@ -154,9 +154,7 @@ export const getCampaignInfluencerProductRepository = (
     CampaignInfluencerProductEntity
   );
 
-  return {
-    ...repo,
-
+  return Object.assign(repo, {
     /**
      * saleId로 판매 상품 조회 (없으면 NotFoundException)
      *
@@ -180,5 +178,5 @@ export const getCampaignInfluencerProductRepository = (
 
       return product;
     },
-  };
+  });
 };

--- a/apps/api/src/module/shared/transaction/repository.provider.ts
+++ b/apps/api/src/module/shared/transaction/repository.provider.ts
@@ -21,7 +21,10 @@ import { getSocialMediaRepository } from '@src/module/backoffice/domain/social-m
 import { getHotelOptionRepository } from '@src/module/backoffice/domain/product/hotel-option.entity';
 import { getCampaignProductRepository } from '@src/module/backoffice/domain/campaign-product.entity';
 import { getCampaignInfluencerRepository } from '@src/module/backoffice/domain/campaign-influencer.entity';
-import { getCampaignInfluencerProductRepository } from '@src/module/backoffice/domain/campaign-influencer-product.entity';
+import {
+  getCampaignInfluencerProductRepository,
+  getCampaignInfluencerProductCustomRepository,
+} from '@src/module/backoffice/domain/campaign-influencer-product.entity';
 import { getCampaignInfluencerHotelOptionRepository } from '@src/module/backoffice/domain/campaign-influencer-hotel-option.entity';
 
 @Injectable()
@@ -114,6 +117,10 @@ export class RepositoryProvider {
 
   get CampaignInfluencerProductRepository() {
     return getCampaignInfluencerProductRepository(this.transaction);
+  }
+
+  get CampaignInfluencerProductCustomRepository() {
+    return getCampaignInfluencerProductCustomRepository(this.transaction);
   }
 
   get CampaignInfluencerHotelOptionRepository() {

--- a/apps/api/src/module/shared/transaction/repository.provider.ts
+++ b/apps/api/src/module/shared/transaction/repository.provider.ts
@@ -21,10 +21,7 @@ import { getSocialMediaRepository } from '@src/module/backoffice/domain/social-m
 import { getHotelOptionRepository } from '@src/module/backoffice/domain/product/hotel-option.entity';
 import { getCampaignProductRepository } from '@src/module/backoffice/domain/campaign-product.entity';
 import { getCampaignInfluencerRepository } from '@src/module/backoffice/domain/campaign-influencer.entity';
-import {
-  getCampaignInfluencerProductRepository,
-  getCampaignInfluencerProductCustomRepository,
-} from '@src/module/backoffice/domain/campaign-influencer-product.entity';
+import { getCampaignInfluencerProductRepository } from '@src/module/backoffice/domain/campaign-influencer-product.entity';
 import { getCampaignInfluencerHotelOptionRepository } from '@src/module/backoffice/domain/campaign-influencer-hotel-option.entity';
 
 @Injectable()
@@ -117,10 +114,6 @@ export class RepositoryProvider {
 
   get CampaignInfluencerProductRepository() {
     return getCampaignInfluencerProductRepository(this.transaction);
-  }
-
-  get CampaignInfluencerProductCustomRepository() {
-    return getCampaignInfluencerProductCustomRepository(this.transaction);
   }
 
   get CampaignInfluencerHotelOptionRepository() {

--- a/apps/api/src/module/shop/influencer/shop.influencer.service.ts
+++ b/apps/api/src/module/shop/influencer/shop.influencer.service.ts
@@ -54,12 +54,24 @@ export class ShopInfluencerService {
       );
     }
 
-    const influencerId = influencer.id;
+    return this.getCampaignsByInfluencerId(influencer.id);
+  }
+
+  /**
+   * 인플루언서 ID로 진행 중인 캠페인 목록 조회
+   *
+   * @param influencerId 인플루언서 ID
+   * @param excludeCampaignId 제외할 캠페인 ID (상품 상세에서 현재 캠페인 제외용)
+   */
+  async getCampaignsByInfluencerId(
+    influencerId: number,
+    excludeCampaignId?: number
+  ): Promise<ShopCampaignListResponse> {
     const now = new Date();
 
     // CampaignInfluencer를 통해 인플루언서의 캠페인 조회
-    const campaignInfluencers =
-      await this.repositoryProvider.CampaignInfluencerRepository.createQueryBuilder(
+    const queryBuilder =
+      this.repositoryProvider.CampaignInfluencerRepository.createQueryBuilder(
         'ci'
       )
         .leftJoinAndSelect('ci.campaign', 'campaign')
@@ -69,8 +81,16 @@ export class ShopInfluencerService {
         .andWhere('ci.status = :status', { status: CampaignStatusEnum.VISIBLE })
         .andWhere('campaign.startAt <= :now', { now })
         .andWhere('campaign.endAt >= :now', { now })
-        .orderBy('campaign.startAt', 'DESC')
-        .getMany();
+        .orderBy('campaign.startAt', 'DESC');
+
+    // 제외할 캠페인이 있으면 필터링
+    if (excludeCampaignId !== undefined) {
+      queryBuilder.andWhere('campaign.id != :excludeCampaignId', {
+        excludeCampaignId,
+      });
+    }
+
+    const campaignInfluencers = await queryBuilder.getMany();
 
     const campaigns: ShopCampaignListItemResponse[] = campaignInfluencers.map(
       campaignInfluencer => {

--- a/apps/api/src/module/shop/influencer/shop.influencer.service.ts
+++ b/apps/api/src/module/shop/influencer/shop.influencer.service.ts
@@ -79,12 +79,15 @@ export class ShopInfluencerService {
         // VISIBLE 상태인 상품만 필터링
         const visibleProducts = (campaignInfluencer.products ?? [])
           .filter(product => product.status === CampaignStatusEnum.VISIBLE)
-          .map(campaignProduct => ({
-            id: campaignProduct.product.id,
-            saleId: campaignProduct.id,
-            name: campaignProduct.product.name,
-            thumbnail: campaignProduct.product.thumbnailUrls?.[0] ?? null,
-          }));
+          .map(campaignProduct => {
+            const shopProduct = campaignProduct.toShopProduct();
+            return {
+              id: shopProduct.id,
+              saleId: shopProduct.saleId,
+              name: shopProduct.name,
+              thumbnail: shopProduct.thumbnail,
+            };
+          });
 
         return {
           id: campaign.id,
@@ -154,14 +157,7 @@ export class ShopInfluencerService {
       .filter(
         campaignProduct => campaignProduct.status === CampaignStatusEnum.VISIBLE
       )
-      .map(campaignProduct => ({
-        id: campaignProduct.product.id,
-        saleId: campaignProduct.id,
-        name: campaignProduct.product.name,
-        thumbnail: campaignProduct.product.thumbnailUrls?.[0] ?? null,
-        originalPrice: campaignProduct.product.originalPrice,
-        price: campaignProduct.product.price,
-      }));
+      .map(campaignProduct => campaignProduct.toShopProduct());
 
     return {
       id: campaign.id,

--- a/apps/api/src/module/shop/product/shop.product.controller.ts
+++ b/apps/api/src/module/shop/product/shop.product.controller.ts
@@ -4,12 +4,15 @@ import { ShopProductService } from './shop.product.service';
 import {
   shopProductDetailSchema,
   campaignOtherProductsSchema,
+  influencerOtherCampaignsSchema,
 } from './shop.product.schema';
 import type {
   GetProductDetailInput,
   ProductDetailResponse,
   GetCampaignOtherProductsInput,
   CampaignOtherProductsResponse,
+  GetInfluencerOtherCampaignsInput,
+  InfluencerOtherCampaignsResponse,
 } from './shop.product.dto';
 
 @Controller()
@@ -31,5 +34,14 @@ export class ShopProductController {
     const result =
       await this.shopProductService.getCampaignOtherProducts(input);
     return campaignOtherProductsSchema.parse(result);
+  }
+
+  @MessagePattern('shopProduct.getInfluencerOtherCampaigns')
+  async getInfluencerOtherCampaigns(
+    input: GetInfluencerOtherCampaignsInput
+  ): Promise<InfluencerOtherCampaignsResponse> {
+    const result =
+      await this.shopProductService.getInfluencerOtherCampaigns(input);
+    return influencerOtherCampaignsSchema.parse(result);
   }
 }

--- a/apps/api/src/module/shop/product/shop.product.controller.ts
+++ b/apps/api/src/module/shop/product/shop.product.controller.ts
@@ -1,10 +1,15 @@
 import { Controller } from '@nestjs/common';
 import { MessagePattern } from '@nestjs/microservices';
 import { ShopProductService } from './shop.product.service';
-import { shopProductDetailSchema } from './shop.product.schema';
+import {
+  shopProductDetailSchema,
+  campaignOtherProductsSchema,
+} from './shop.product.schema';
 import type {
   GetProductDetailInput,
   ProductDetailResponse,
+  GetCampaignOtherProductsInput,
+  CampaignOtherProductsResponse,
 } from './shop.product.dto';
 
 @Controller()
@@ -17,5 +22,14 @@ export class ShopProductController {
   ): Promise<ProductDetailResponse> {
     const result = await this.shopProductService.getProductDetail(input);
     return shopProductDetailSchema.parse(result);
+  }
+
+  @MessagePattern('shopProduct.getCampaignOtherProducts')
+  async getCampaignOtherProducts(
+    input: GetCampaignOtherProductsInput
+  ): Promise<CampaignOtherProductsResponse> {
+    const result =
+      await this.shopProductService.getCampaignOtherProducts(input);
+    return campaignOtherProductsSchema.parse(result);
   }
 }

--- a/apps/api/src/module/shop/product/shop.product.dto.ts
+++ b/apps/api/src/module/shop/product/shop.product.dto.ts
@@ -1,5 +1,8 @@
 import type { z } from 'zod';
-import type { shopProductDetailSchema } from './shop.product.schema';
+import type {
+  shopProductDetailSchema,
+  campaignOtherProductsSchema,
+} from './shop.product.schema';
 
 /**
  * 상품 상세 응답 (Zod 스키마에서 추론)
@@ -74,3 +77,17 @@ export interface BaseSalesInfo {
   // exchangeReturnInfo: ExchangeReturnInfo;
   // productInfoNotice: string | null;
 }
+
+/**
+ * 캠페인 다른 상품 조회 입력
+ */
+export interface GetCampaignOtherProductsInput {
+  saleId: number;
+}
+
+/**
+ * 캠페인 다른 상품 응답 (Zod 스키마에서 추론)
+ */
+export type CampaignOtherProductsResponse = z.infer<
+  typeof campaignOtherProductsSchema
+>;

--- a/apps/api/src/module/shop/product/shop.product.dto.ts
+++ b/apps/api/src/module/shop/product/shop.product.dto.ts
@@ -2,6 +2,7 @@ import type { z } from 'zod';
 import type {
   shopProductDetailSchema,
   campaignOtherProductsSchema,
+  influencerOtherCampaignsSchema,
 } from './shop.product.schema';
 
 /**
@@ -90,4 +91,18 @@ export interface GetCampaignOtherProductsInput {
  */
 export type CampaignOtherProductsResponse = z.infer<
   typeof campaignOtherProductsSchema
+>;
+
+/**
+ * 인플루언서 다른 캠페인 조회 입력
+ */
+export interface GetInfluencerOtherCampaignsInput {
+  saleId: number;
+}
+
+/**
+ * 인플루언서 다른 캠페인 응답 (Zod 스키마에서 추론)
+ */
+export type InfluencerOtherCampaignsResponse = z.infer<
+  typeof influencerOtherCampaignsSchema
 >;

--- a/apps/api/src/module/shop/product/shop.product.module.ts
+++ b/apps/api/src/module/shop/product/shop.product.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ShopProductController } from './shop.product.controller';
 import { ShopProductService } from './shop.product.service';
+import { ShopInfluencerModule } from '@src/module/shop/influencer/shop.influencer.module';
 
 @Module({
+  imports: [ShopInfluencerModule],
   controllers: [ShopProductController],
   providers: [ShopProductService],
   exports: [ShopProductService],

--- a/apps/api/src/module/shop/product/shop.product.router.ts
+++ b/apps/api/src/module/shop/product/shop.product.router.ts
@@ -5,6 +5,7 @@ import { BaseTrpcRouter } from '@src/module/trpc/baseTrpcRouter';
 import {
   shopProductDetailSchema,
   campaignOtherProductsSchema,
+  influencerOtherCampaignsSchema,
 } from './shop.product.schema';
 
 @Router({ alias: 'shopProduct' })
@@ -41,6 +42,25 @@ export class ShopProductRouter extends BaseTrpcRouter {
   async getCampaignOtherProducts(@Input() input: { saleId: number }) {
     return this.microserviceClient.send(
       'shopProduct.getCampaignOtherProducts',
+      input
+    );
+  }
+
+  /**
+   * 인플루언서 다른 캠페인 조회
+   *
+   * 현재 상품의 인플루언서가 진행하는 다른 캠페인들을 조회합니다.
+   * saleId: CampaignInfluencerProduct.id
+   */
+  @Query({
+    input: z.object({
+      saleId: z.number(),
+    }),
+    output: influencerOtherCampaignsSchema,
+  })
+  async getInfluencerOtherCampaigns(@Input() input: { saleId: number }) {
+    return this.microserviceClient.send(
+      'shopProduct.getInfluencerOtherCampaigns',
       input
     );
   }

--- a/apps/api/src/module/shop/product/shop.product.router.ts
+++ b/apps/api/src/module/shop/product/shop.product.router.ts
@@ -2,7 +2,10 @@ import { Router, Query, Input } from 'nestjs-trpc';
 import { z } from 'zod';
 import { Injectable } from '@nestjs/common';
 import { BaseTrpcRouter } from '@src/module/trpc/baseTrpcRouter';
-import { shopProductDetailSchema } from './shop.product.schema';
+import {
+  shopProductDetailSchema,
+  campaignOtherProductsSchema,
+} from './shop.product.schema';
 
 @Router({ alias: 'shopProduct' })
 @Injectable()
@@ -21,5 +24,24 @@ export class ShopProductRouter extends BaseTrpcRouter {
   })
   async getProductDetail(@Input() input: { saleId: number }) {
     return this.microserviceClient.send('shopProduct.getDetail', input);
+  }
+
+  /**
+   * 캠페인 다른 상품 조회
+   *
+   * 현재 상품이 포함된 캠페인의 다른 상품들을 조회합니다.
+   * saleId: CampaignInfluencerProduct.id
+   */
+  @Query({
+    input: z.object({
+      saleId: z.number(),
+    }),
+    output: campaignOtherProductsSchema,
+  })
+  async getCampaignOtherProducts(@Input() input: { saleId: number }) {
+    return this.microserviceClient.send(
+      'shopProduct.getCampaignOtherProducts',
+      input
+    );
   }
 }

--- a/apps/api/src/module/shop/product/shop.product.schema.ts
+++ b/apps/api/src/module/shop/product/shop.product.schema.ts
@@ -195,3 +195,26 @@ export const shopProductDetailSchema = z.discriminatedUnion('type', [
   deliveryProductDetailSchema,
   eTicketProductDetailSchema,
 ]);
+
+/**
+ * 캠페인 다른 상품 목록 스키마
+ *
+ * 현재 상품이 포함된 캠페인의 다른 상품들을 조회합니다.
+ */
+export const campaignOtherProductsSchema = z.object({
+  campaign: z.object({
+    id: z.number(),
+    name: z.string(),
+    startAt: z.date(),
+    endAt: z.date(),
+  }),
+  products: z.array(
+    z.object({
+      id: z.number(), // CampaignInfluencerProduct.id (saleId)
+      thumbnailUrl: z.string().nullish(),
+      name: z.string(),
+      originalPrice: z.number(),
+      price: z.number(),
+    })
+  ),
+});

--- a/apps/api/src/module/shop/product/shop.product.schema.ts
+++ b/apps/api/src/module/shop/product/shop.product.schema.ts
@@ -218,3 +218,27 @@ export const campaignOtherProductsSchema = z.object({
     })
   ),
 });
+
+/**
+ * 인플루언서 다른 캠페인 목록 스키마
+ *
+ * 현재 상품의 인플루언서가 진행하는 다른 캠페인들을 조회합니다.
+ */
+export const influencerOtherCampaignsSchema = z.object({
+  campaigns: z.array(
+    z.object({
+      id: z.number(),
+      title: z.string(),
+      startAt: z.date(),
+      endAt: z.date(),
+      products: z.array(
+        z.object({
+          id: z.number(), // product.id
+          saleId: z.number(), // CampaignInfluencerProduct.id
+          name: z.string(),
+          thumbnail: z.string().nullish(),
+        })
+      ),
+    })
+  ),
+});

--- a/apps/api/src/module/shop/product/shop.product.service.ts
+++ b/apps/api/src/module/shop/product/shop.product.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { RepositoryProvider } from '@src/module/shared/transaction/repository.provider';
 import { ProductTypeEnum } from '@src/module/backoffice/admin/admin.schema';
 import type {
@@ -6,6 +6,8 @@ import type {
   GetProductDetailInput,
   HotelProductDetails,
   SellerInfo,
+  GetCampaignOtherProductsInput,
+  CampaignOtherProductsResponse,
 } from './shop.product.dto';
 import type { BrandEntity } from '@src/module/backoffice/domain/brand.entity';
 
@@ -30,24 +32,16 @@ export class ShopProductService {
 
     // 1. CampaignInfluencerProduct 조회 (with relations)
     const campaignInfluencerProduct =
-      await this.repositoryProvider.CampaignInfluencerProductRepository.findOne(
-        {
-          where: { id: saleId },
-          relations: [
-            'campaignInfluencer',
-            'campaignInfluencer.campaign',
-            'campaignInfluencer.influencer',
-            'product',
-            'product.brand',
-          ],
-        }
+      await this.repositoryProvider.CampaignInfluencerProductCustomRepository.findBySaleIdOrFail(
+        saleId,
+        [
+          'campaignInfluencer',
+          'campaignInfluencer.campaign',
+          'campaignInfluencer.influencer',
+          'product',
+          'product.brand',
+        ]
       );
-
-    if (!campaignInfluencerProduct) {
-      throw new NotFoundException(
-        `판매 상품을 찾을 수 없습니다 (ID: ${saleId})`
-      );
-    }
 
     const { campaignInfluencer, product } = campaignInfluencerProduct;
     const { campaign, influencer } = campaignInfluencer;
@@ -209,6 +203,59 @@ export class ShopProductService {
       address: businessInfo?.address ?? null,
       licenseNumber: businessInfo?.licenseNumber ?? null,
       mailOrderLicenseNumber: businessInfo?.mailOrderLicenseNumber ?? null,
+    };
+  }
+
+  /**
+   * 캠페인 다른 상품 조회
+   *
+   * 현재 상품(saleId)이 포함된 캠페인의 다른 상품들을 조회합니다.
+   *
+   * 조회 흐름:
+   * 1. saleId로 CampaignInfluencerProduct 조회 → campaignId 획득
+   * 2. 같은 캠페인의 다른 CampaignInfluencerProduct 조회 (현재 상품 제외)
+   */
+  async getCampaignOtherProducts(
+    input: GetCampaignOtherProductsInput
+  ): Promise<CampaignOtherProductsResponse> {
+    const { saleId } = input;
+
+    // 1. 현재 상품에서 캠페인 정보 조회
+    const currentProduct =
+      await this.repositoryProvider.CampaignInfluencerProductCustomRepository.findBySaleIdOrFail(
+        saleId,
+        ['campaignInfluencer', 'campaignInfluencer.campaign']
+      );
+
+    const campaign = currentProduct.campaignInfluencer.campaign;
+    const campaignInfluencerId = currentProduct.campaignInfluencerId;
+
+    // 2. 같은 CampaignInfluencer의 다른 상품들 조회 (현재 상품 제외)
+    const otherProducts =
+      await this.repositoryProvider.CampaignInfluencerProductRepository.find({
+        where: { campaignInfluencerId },
+        relations: ['product'],
+      });
+
+    // 현재 상품 제외 및 응답 형식 변환
+    const products = otherProducts
+      .filter(item => item.id !== saleId)
+      .map(item => ({
+        id: item.id,
+        thumbnailUrl: item.product.thumbnailUrls?.[0] ?? null,
+        name: item.product.name,
+        originalPrice: item.product.originalPrice,
+        price: item.product.price,
+      }));
+
+    return {
+      campaign: {
+        id: campaign.id,
+        name: campaign.title,
+        startAt: campaign.startAt,
+        endAt: campaign.endAt,
+      },
+      products,
     };
   }
 }

--- a/apps/api/src/module/shop/product/shop.product.service.ts
+++ b/apps/api/src/module/shop/product/shop.product.service.ts
@@ -240,13 +240,7 @@ export class ShopProductService {
     // 현재 상품 제외 및 응답 형식 변환
     const products = otherProducts
       .filter(item => item.id !== saleId)
-      .map(item => ({
-        id: item.id,
-        thumbnailUrl: item.product.thumbnailUrls?.[0] ?? null,
-        name: item.product.name,
-        originalPrice: item.product.originalPrice,
-        price: item.product.price,
-      }));
+      .map(item => item.toProductSummary());
 
     return {
       campaign: {

--- a/apps/api/src/module/shop/product/shop.product.service.ts
+++ b/apps/api/src/module/shop/product/shop.product.service.ts
@@ -32,7 +32,7 @@ export class ShopProductService {
 
     // 1. CampaignInfluencerProduct 조회 (with relations)
     const campaignInfluencerProduct =
-      await this.repositoryProvider.CampaignInfluencerProductCustomRepository.findBySaleIdOrFail(
+      await this.repositoryProvider.CampaignInfluencerProductRepository.findBySaleIdOrFail(
         saleId,
         [
           'campaignInfluencer',
@@ -222,7 +222,7 @@ export class ShopProductService {
 
     // 1. 현재 상품에서 캠페인 정보 조회
     const currentProduct =
-      await this.repositoryProvider.CampaignInfluencerProductCustomRepository.findBySaleIdOrFail(
+      await this.repositoryProvider.CampaignInfluencerProductRepository.findBySaleIdOrFail(
         saleId,
         ['campaignInfluencer', 'campaignInfluencer.campaign']
       );

--- a/apps/api/src/module/shop/product/shop.product.service.ts
+++ b/apps/api/src/module/shop/product/shop.product.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { RepositoryProvider } from '@src/module/shared/transaction/repository.provider';
 import { ProductTypeEnum } from '@src/module/backoffice/admin/admin.schema';
+import { ShopInfluencerService } from '@src/module/shop/influencer/shop.influencer.service';
 import type {
   ProductDetailResponse,
   GetProductDetailInput,
@@ -8,12 +9,17 @@ import type {
   SellerInfo,
   GetCampaignOtherProductsInput,
   CampaignOtherProductsResponse,
+  GetInfluencerOtherCampaignsInput,
+  InfluencerOtherCampaignsResponse,
 } from './shop.product.dto';
 import type { BrandEntity } from '@src/module/backoffice/domain/brand.entity';
 
 @Injectable()
 export class ShopProductService {
-  constructor(private readonly repositoryProvider: RepositoryProvider) {}
+  constructor(
+    private readonly repositoryProvider: RepositoryProvider,
+    private readonly shopInfluencerService: ShopInfluencerService
+  ) {}
 
   /**
    * 상품 상세 조회
@@ -251,5 +257,33 @@ export class ShopProductService {
       },
       products,
     };
+  }
+
+  /**
+   * 인플루언서 다른 캠페인 조회
+   *
+   * 현재 상품의 인플루언서가 진행하는 다른 캠페인들을 조회합니다.
+   * ShopInfluencerService의 getCampaignsByInfluencerId를 재사용합니다.
+   */
+  async getInfluencerOtherCampaigns(
+    input: GetInfluencerOtherCampaignsInput
+  ): Promise<InfluencerOtherCampaignsResponse> {
+    const { saleId } = input;
+
+    // 1. 현재 상품에서 인플루언서, 캠페인 정보 조회
+    const currentProduct =
+      await this.repositoryProvider.CampaignInfluencerProductRepository.findBySaleIdOrFail(
+        saleId,
+        ['campaignInfluencer', 'campaignInfluencer.campaign']
+      );
+
+    const influencerId = currentProduct.campaignInfluencer.influencerId;
+    const currentCampaignId = currentProduct.campaignInfluencer.campaign.id;
+
+    // 2. ShopInfluencerService를 통해 다른 캠페인들 조회 (현재 캠페인 제외)
+    return this.shopInfluencerService.getCampaignsByInfluencerId(
+      influencerId,
+      currentCampaignId
+    );
   }
 }

--- a/packages/api-types/src/server.ts
+++ b/packages/api-types/src/server.ts
@@ -227,6 +227,26 @@ const appRouter = t.router({
           price: z.number(),
         })
       ),
+    })).query(async () => "PLACEHOLDER_DO_NOT_REMOVE" as any),
+    getInfluencerOtherCampaigns: publicProcedure.input(z.object({
+      saleId: z.number(),
+    })).output(z.object({
+      campaigns: z.array(
+        z.object({
+          id: z.number(),
+          title: z.string(),
+          startAt: z.date(),
+          endAt: z.date(),
+          products: z.array(
+            z.object({
+              id: z.number(), // product.id
+              saleId: z.number(), // CampaignInfluencerProduct.id
+              name: z.string(),
+              thumbnail: z.string().nullish(),
+            })
+          ),
+        })
+      ),
     })).query(async () => "PLACEHOLDER_DO_NOT_REMOVE" as any)
   }),
   shopPayment: t.router({

--- a/packages/api-types/src/server.ts
+++ b/packages/api-types/src/server.ts
@@ -208,7 +208,26 @@ const appRouter = t.router({
           }),
         }),
       }),
-    ])).query(async () => "PLACEHOLDER_DO_NOT_REMOVE" as any)
+    ])).query(async () => "PLACEHOLDER_DO_NOT_REMOVE" as any),
+    getCampaignOtherProducts: publicProcedure.input(z.object({
+      saleId: z.number(),
+    })).output(z.object({
+      campaign: z.object({
+        id: z.number(),
+        name: z.string(),
+        startAt: z.date(),
+        endAt: z.date(),
+      }),
+      products: z.array(
+        z.object({
+          id: z.number(), // CampaignInfluencerProduct.id (saleId)
+          thumbnailUrl: z.string().nullish(),
+          name: z.string(),
+          originalPrice: z.number(),
+          price: z.number(),
+        })
+      ),
+    })).query(async () => "PLACEHOLDER_DO_NOT_REMOVE" as any)
   }),
   shopPayment: t.router({
     complete: publicProcedure.input(z.object({


### PR DESCRIPTION
## Summary
- `shopProduct.getCampaignOtherProducts` API 추가: 현재 상품이 포함된 캠페인의 다른 상품들 조회
- `CampaignInfluencerProductCustomRepository` 추가: `findBySaleIdOrFail` 메서드로 중복 코드 제거

<img width="501" height="583" alt="image" src="https://github.com/user-attachments/assets/b61aa5dc-ae17-4d3e-be98-e7cbe1a74755" />
상품품상세에 여기 부분 api요

## 변경 사항

### 새 API: `shopProduct.getCampaignOtherProducts`
**입력:** `{ saleId: number }`

**출력:**
```typescript
{
  campaign: { id, name, startAt, endAt },
  products: [{ id, thumbnailUrl, name, originalPrice, price }]
}
```

### Custom Repository 패턴 적용
- Entity 파일에 `getCampaignInfluencerProductCustomRepository` 함수 추가
- `RepositoryProvider`에 getter 추가
- `ShopProductService`에서 중복 조회 로직 제거

## Test plan
- [ ] `shopProduct.getCampaignOtherProducts` API 호출 테스트
- [ ] 현재 상품이 제외되는지 확인
- [ ] 존재하지 않는 saleId로 호출 시 404 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)