### PR TITLE
FEAT: PR Review Skill 추가 (YesTravel 컨벤션 적용)

### DIFF
--- a/.claude/skills/be-checklist.md
+++ b/.claude/skills/be-checklist.md
@@ -1,0 +1,156 @@
+# Backend PR Checklist
+
+## API Design
+
+- [ ] RESTful conventions followed (or GraphQL schema appropriate)
+- [ ] HTTP methods appropriate (GET/POST/PUT/PATCH/DELETE)
+- [ ] Status codes correct (200, 201, 400, 401, 403, 404, 500)
+- [ ] Response format consistent
+- [ ] API versioning considered
+- [ ] Rate limiting needed
+
+## Input Validation
+
+- [ ] All inputs validated (DTO validation)
+- [ ] SQL Injection prevented
+- [ ] XSS prevented
+- [ ] File upload validated (type, size)
+- [ ] Boundary values tested (min, max, null, empty)
+
+## Authentication/Authorization
+
+- [ ] Protected endpoints require authentication
+- [ ] Permission checks appropriate
+- [ ] JWT/session handling appropriate
+- [ ] Sensitive data access restricted
+- [ ] CORS settings appropriate
+
+## Database
+
+- [ ] Query optimization (no N+1 problems)
+- [ ] Indexes needed
+- [ ] Transaction scope appropriate
+- [ ] No deadlock potential
+- [ ] Migration rollback possible
+- [ ] Soft delete vs Hard delete appropriate
+
+## Error Handling
+
+- [ ] Exception handling appropriate
+- [ ] Error messages user-friendly (no internal info exposed)
+- [ ] Global exception handler used
+- [ ] Error logging appropriate
+- [ ] Retry logic needed
+
+## Logging/Monitoring
+
+- [ ] Appropriate log levels used (debug, info, warn, error)
+- [ ] No sensitive info in logs
+- [ ] Request tracking ID (correlation ID)
+- [ ] Metric collection points
+
+## Performance
+
+- [ ] No unnecessary DB calls
+- [ ] Caching needed
+- [ ] Pagination applied
+- [ ] Async processing appropriate
+- [ ] Large data streaming handled
+- [ ] Connection pool configured
+
+## Concurrency/Distributed
+
+- [ ] No race conditions
+- [ ] Distributed lock needed
+- [ ] Idempotency guaranteed
+- [ ] Message queue handling (retry, DLQ)
+- [ ] Distributed transactions considered
+
+## Security
+
+- [ ] No hardcoded secrets/keys
+- [ ] Config managed via environment variables
+- [ ] HTTPS enforced
+- [ ] Security headers configured
+- [ ] Dependency security vulnerabilities checked
+
+## Testing
+
+- [ ] Unit test coverage
+- [ ] Integration tests (DB, external services)
+- [ ] API tests (E2E)
+- [ ] Mocks used appropriately
+- [ ] Edge cases tested
+- [ ] Load testing needed
+
+## Documentation
+
+- [ ] API docs updated (Swagger/OpenAPI)
+- [ ] README update needed
+- [ ] Comments accurate
+- [ ] CHANGELOG updated
+
+---
+
+## YesTravel Backend Conventions
+
+### Coding Style
+
+- [ ] **No await in for loops** - Use `Promise.all()` + `map()` pattern
+- [ ] **No single-letter variables** - Use `item`, `product` instead of `i`, `p`, `x`
+- [ ] **Functional methods** - Use `map`, `filter`, `reduce` instead of `for` loops
+
+### Schema & Type Patterns
+
+- [ ] **DTO files separated** - No interface definitions inside Service files, use `*.dto.ts`
+- [ ] **nullish() unified** - Use `nullish()` instead of `optional().nullable()`
+- [ ] **Update schema pattern** - Use `createSchema.extend({ id: z.number() })`
+- [ ] **Entity retrieval** - Use `findOneOrFail` + `.catch()` pattern
+
+### tRPC + NestJS Architecture
+
+- [ ] **Router decorator import** - Must import from `'nestjs-trpc'` package
+- [ ] **Router not in providers** - Router should NOT be in Module's providers (auto-discovered)
+- [ ] **MessagePattern naming** - Follow `moduleName.methodName` pattern
+- [ ] **Schema validation** - Input/output schema defined in Router
+- [ ] **Response formatting** - Controller formats response to match schema (remove TypeORM metadata)
+
+### Repository Patterns
+
+- [ ] **No TypeOrmModule.forFeature()** - Use `RepositoryProvider` only
+- [ ] **Custom repository extend()** - Use `.extend({})` pattern, NOT `Object.assign()`
+- [ ] **Entity location** - All entities in `apps/api/src/module/backoffice/domain/`
+
+### Transaction Management
+
+- [ ] **@Transactional decorator** - Applied to mutation methods in Service
+- [ ] **TransactionService injection** - Controller must inject `TransactionService`
+
+### Migration Rules
+
+- [ ] **Use yarn migration:create** - Don't let AI generate timestamp manually
+- [ ] **INHERITS columns** - Add/remove columns on parent table only (auto-inherited)
+- [ ] **No TypeORM inheritance decorators** - Don't use `@TableInheritance`, `@ChildEntity`
+- [ ] **Parent table query** - Use Raw Query for INHERITS parent table (no QueryBuilder)
+
+### Entity Conventions
+
+- [ ] **Soft delete auto-applied** - No need for `deletedAt: null` condition
+- [ ] **Nullish type** - Use `Nullish<T>` from `@src/types/utility.type` for nullable columns
+
+### Enum Naming
+
+- [ ] **Value array**: `{NAME}_ENUM_VALUE` (e.g., `ROLE_ENUM_VALUE`)
+- [ ] **Type**: `{Name}EnumType` (e.g., `RoleEnumType`)
+- [ ] **Object**: `{Name}Enum` (e.g., `RoleEnum`)
+- [ ] **Schema**: `{name}EnumSchema` (e.g., `roleEnumSchema`)
+
+### Index & Constraints
+
+- [ ] **Composite index** - Add for frequently queried column combinations
+- [ ] **Foreign key** - Must be added to each INHERITS child table individually
+
+### Error Handling
+
+- [ ] **NestJS HttpException** - Use `NotFoundException`, `BadRequestException`, etc.
+- [ ] **Auto-converted to tRPC** - Errors automatically converted to appropriate tRPC error codes

--- a/.claude/skills/fe-checklist.md
+++ b/.claude/skills/fe-checklist.md
@@ -1,0 +1,230 @@
+# Frontend PR Checklist
+
+## React Components
+
+- [ ] Hook dependency arrays correct (useEffect, useMemo, useCallback)
+- [ ] No unnecessary re-renders
+- [ ] Unique key props on list items
+- [ ] Event handler cleanup (useEffect return)
+- [ ] Conditional rendering edge cases handled
+- [ ] Loading/error/empty states handled
+- [ ] Single responsibility (SRP)
+
+## State Management
+
+- [ ] State location appropriate (local vs global)
+- [ ] No unnecessary global state
+- [ ] Derived state computed instead of stored
+- [ ] State updates batched properly
+- [ ] Optimistic updates used appropriately
+
+## TypeScript
+
+- [ ] No unjustified `any` usage
+- [ ] Strict null checks
+- [ ] Generic constraints appropriate
+- [ ] Props types clearly defined
+- [ ] Discriminated unions utilized
+
+## Styling
+
+- [ ] Consistent styling approach (CSS-in-JS, Tailwind, etc.)
+- [ ] Responsive design
+- [ ] Dark mode support (if needed)
+- [ ] z-index management
+- [ ] Animation performance (transform, opacity)
+
+## Accessibility (a11y)
+
+- [ ] Semantic HTML used
+- [ ] aria attributes appropriate
+- [ ] Keyboard navigation works
+- [ ] Focus management
+- [ ] Sufficient color contrast
+
+## Performance
+
+- [ ] Bundle size impact checked
+- [ ] Lazy loading (React.lazy, dynamic import)
+- [ ] Image optimization (next/image, srcset)
+- [ ] Memoization appropriate (avoid excessive useMemo)
+- [ ] Virtualization needed (long lists)
+
+## Async Handling
+
+- [ ] Loading states displayed
+- [ ] Error boundaries applied
+- [ ] AbortController for request cancellation
+- [ ] Race conditions prevented
+- [ ] Retry logic (if needed)
+
+## Form Handling
+
+- [ ] Validation (client + server)
+- [ ] User-friendly error messages
+- [ ] Duplicate submission prevention
+- [ ] Form state reset properly
+
+## Testing
+
+- [ ] Component unit tests
+- [ ] User interaction tests
+- [ ] Snapshot tests needed
+- [ ] E2E tests updated
+- [ ] Mocks used appropriately
+
+## Security
+
+- [ ] XSS prevention (careful with dangerouslySetInnerHTML)
+- [ ] No sensitive data exposed to client
+- [ ] HTTPS used
+- [ ] External library security vulnerabilities checked
+
+---
+
+## YesTravel Frontend Conventions
+
+### Styling Rules (MANDATORY)
+
+- [ ] **tailwind-styled-components required** - No `className` prop usage
+- [ ] **Styled components at bottom** - All `tw.*` definitions at file bottom
+- [ ] **Conditional props with $prefix** - Use `$primary`, `$active` (not `primary`)
+
+```typescript
+// Correct
+const Button = tw.button<{ $primary?: boolean }>`
+  px-4 py-2
+  ${({ $primary }) => $primary ? 'bg-blue-500' : 'bg-gray-500'}
+`;
+
+// Wrong - className usage
+<div className="flex flex-col" />
+```
+
+### Icons
+
+- [ ] **lucide-react only** - No font emojis, no custom SVG
+- [ ] **Consistent sizing** - Use `size` prop for icon dimensions
+
+```typescript
+import { Home, Search } from 'lucide-react';
+<Home size={20} />
+```
+
+### Color Variables
+
+- [ ] **stroke-* variables with var()** - Must use `var()` function for stroke colors
+
+```typescript
+// Correct
+<div className="outline-[var(--stroke-neutral)]" />
+<input className="border-[var(--stroke-hover)]" />
+
+// Wrong - conflicts with SVG stroke
+<div className="outline-stroke-neutral" />
+```
+
+- [ ] **Other colors normal** - `fg-*`, `bg-*` can be used directly
+
+```typescript
+<div className="bg-bg-layer text-fg-neutral" />
+```
+
+### Font
+
+- [ ] **No font-['Min_Sans_VF']** - Font is globally configured in tailwind.config.ts
+
+### Modal Pattern (react-snappy-modal)
+
+- [ ] **useCurrentModal().resolveModal()** - NOT `SnappyModal.close()`
+- [ ] **Modal + open function in same file** - Export `open{Name}Modal` function
+- [ ] **Promise-based** - Use `.then()` to handle modal result
+
+```typescript
+import SnappyModal, { useCurrentModal } from 'react-snappy-modal';
+
+function MyModal() {
+  const { resolveModal } = useCurrentModal();
+
+  const handleConfirm = () => resolveModal({ data: 'value' });
+  const handleCancel = () => resolveModal(null);
+
+  return <div>...</div>;
+}
+
+export function openMyModal() {
+  return SnappyModal.show(<MyModal />);
+}
+```
+
+### Notifications
+
+- [ ] **No alert()** - Use `toast` from `sonner`
+
+```typescript
+import { toast } from 'sonner';
+toast.success('Success message');
+toast.error('Error message');
+```
+
+### State Management (Zustand)
+
+- [ ] **Zustand for global state** - Use `create` from `zustand`
+- [ ] **persist middleware** - For auth/session state
+
+### Routing (TanStack Router)
+
+- [ ] **File-based routing** - Routes in `src/routes/`
+- [ ] **Protected routes** - Use `beforeLoad` for auth checks
+
+### API Integration (tRPC)
+
+- [ ] **useSuspenseQuery** - For data fetching with Suspense
+- [ ] **useMutation with invalidate** - Invalidate queries after mutation
+
+```typescript
+const createMutation = trpc.module.create.useMutation({
+  onSuccess: () => {
+    trpc.useUtils().module.findAll.invalidate();
+  },
+});
+```
+
+### Form Handling (React Hook Form)
+
+- [ ] **zodResolver** - Use Zod schema for validation
+- [ ] **Controlled components** - Use `Controller` for custom inputs
+
+### Component Patterns
+
+- [ ] **MajorPageLayout** - Use for main page layouts
+- [ ] **Suspense + fallback** - Use `TableSkeleton` for loading states
+- [ ] **EmptyState** - Use for empty data states
+
+### File Structure
+
+- [ ] **_components folder** - Page-specific components in `_components/`
+- [ ] **index.ts exports** - Organize exports via index files
+
+### New Component Requirements
+
+- [ ] **Description comment** - JSDoc comment explaining component purpose
+- [ ] **Usage example** - Include usage example in comment
+
+```typescript
+/**
+ * FileUpload - File upload component
+ * Uploads images and provides preview.
+ */
+export interface FileUploadProps {
+  /** URL of uploaded file */
+  value?: string | null;
+  /** Callback when upload completes */
+  onChange: (url: string | null) => void;
+}
+
+/**
+ * Usage:
+ * <FileUpload value={imageUrl} onChange={setImageUrl} />
+ */
+```

--- a/.claude/skills/pr-review.md
+++ b/.claude/skills/pr-review.md
@@ -1,0 +1,76 @@
+---
+name: pr-review
+description: Systematic PR (Pull Request) code review with structured checklist approach. Use when reviewing GitHub/GitLab PR diffs, code changes, merge requests, or when user asks to review code changes with phrases like "review this PR", "check this code change", "review my merge request", or provides diff/patch content.
+---
+
+# PR Review Skill
+
+Systematic Pull Request review using checklist methodology.
+
+## Review Workflow
+
+### Step 1: Generate Review Plan
+
+```markdown
+## PR Review Plan
+
+- [ ] **Understand PR scope**
+  - Purpose:
+  - Expected behavior change:
+
+- [ ] **Review by file**
+  - [ ] `file1.ts` - description
+  - [ ] `file2.tsx` - description
+
+- [ ] **Implementation quality**
+  - [ ] Logic correctness
+  - [ ] Error handling
+  - [ ] Edge cases
+  - [ ] Type safety
+
+- [ ] **Best practices**
+  - [ ] Maintainability
+  - [ ] Performance
+  - [ ] Security
+
+- [ ] **Integration**
+  - [ ] Breaking changes
+  - [ ] API contracts
+
+- [ ] **Documentation**
+  - [ ] Comments accuracy
+```
+
+### Step 2: Execute Review
+
+- Mark completed items with `[x]`
+- Add inline comments for issues
+- Categorize by severity
+
+### Step 3: Output Summary
+
+```markdown
+## Summary: ✅ Approved / ⚠️ Changes Requested / ❌ Blocked
+
+### 🔴 Critical (Must Fix)
+### 🟡 Suggestions (Nice to Have)
+### 🔵 Questions
+### 🟢 Highlights
+```
+
+## Focus by PR Type
+
+| Type | Focus Areas |
+|------|-------------|
+| Feature | Logic, tests, docs |
+| Bugfix | Root cause, regression |
+| Refactor | Behavior preservation, performance |
+| Config | Security, environment compatibility |
+| Dependency | Breaking changes, security vulnerabilities |
+
+## Tech-Specific Checklists
+
+Reference appropriate checklist based on PR content:
+
+- **Frontend**: `.claude/skills/fe-checklist.md`
+- **Backend**: `.claude/skills/be-checklist.md`


### PR DESCRIPTION
## Summary

- PR 리뷰를 위한 체계적인 체크리스트 기반 Claude Code Skill 추가
- `/pr-review` 명령어로 PR 코드 리뷰 수행 가능

## 추가된 파일

| 파일 | 설명 |
|-----|------|
| `.claude/skills/pr-review.md` | PR Review Skill 정의 (워크플로우, PR 타입별 Focus) |
| `.claude/skills/be-checklist.md` | Backend 체크리스트 (tRPC+NestJS, Repository 패턴, Migration 규칙 등) |
| `.claude/skills/fe-checklist.md` | Frontend 체크리스트 (tailwind-styled-components, Modal 패턴, 아이콘 규칙 등) |

## 사용 방법

```bash
# 슬래시 명령어
/pr-review

# 자연어 요청
"PR #123 리뷰해줘"
"feat/shop-auth 브랜치 코드 리뷰해줘"
```

## 리뷰 출력 예시

```markdown
## Summary: ⚠️ Changes Requested

### 🔴 Critical (Must Fix)
- Migration 타임스탬프 수동 생성 → `yarn migration:create` 사용 필요

### 🟡 Suggestions
- jsonb 대신 @Column(() => AddressEntity) 사용 권장
```

## Test plan

- [ ] `/pr-review` 명령어 실행 확인
- [ ] Backend PR 리뷰 시 be-checklist 참조 확인
- [ ] Frontend PR 리뷰 시 fe-checklist 참조 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)