### PR TITLE
FEAT: 로그인 바텀시트 Figma 디자인 적용 및 공통 Button 컴포넌트 추가

### DIFF
--- a/apps/shop/src/components/auth/LoginBottomSheet.tsx
+++ b/apps/shop/src/components/auth/LoginBottomSheet.tsx
@@ -106,10 +106,6 @@ function LoginBottomSheet() {
         onClick={(e: React.MouseEvent) => e.stopPropagation()}
         style={{ marginBottom: keyboardHeight }}
       >
-        <HandleWrapper>
-          <Handle />
-        </HandleWrapper>
-
         {step === 'login' && (
           <LoginStep
             phoneNumber={phoneNumber}
@@ -171,21 +167,4 @@ const BottomSheetContainer = tw.div`
   overflow-hidden
   transition-all
   duration-200
-`;
-
-const HandleWrapper = tw.div`
-  px-5
-  pt-3
-  pb-2
-  bg-white
-  flex
-  flex-col
-  items-center
-`;
-
-const Handle = tw.div`
-  w-12
-  h-1
-  bg-[var(--stroke-neutral)]
-  rounded-sm
 `;

--- a/apps/shop/src/components/auth/LoginStep.tsx
+++ b/apps/shop/src/components/auth/LoginStep.tsx
@@ -16,6 +16,8 @@
 
 import tw from 'tailwind-styled-components';
 
+import { Button } from '@/components/common';
+
 export interface LoginStepProps {
   phoneNumber: string;
   onPhoneNumberChange: (value: string) => void;
@@ -44,25 +46,32 @@ export function LoginStep({
 
   return (
     <StepContent>
+      {/* 상단 라운드 여백 */}
+      <TopSpacer />
+
+      {/* 로그인 타이틀 */}
+      <Title>로그인</Title>
+
       {/* 비회원 로그인 섹션 */}
       <Section>
-        <SectionTitle>비회원으로 시작하기</SectionTitle>
+        <SectionLabel>비회원으로 시작하기</SectionLabel>
         <PhoneInput
           type="tel"
           inputMode="numeric"
-          placeholder="01012345678"
+          placeholder="연락처를 입력해 주세요."
           value={phoneNumber}
           onChange={handlePhoneChange}
           maxLength={11}
         />
         {error && <ErrorMessage>{error}</ErrorMessage>}
-        <PrimaryButton
-          onClick={onRequestOTP}
-          disabled={!isValidPhoneNumber || isLoading}
-        >
-          {isLoading ? '발송 중...' : '연락처 인증'}
-        </PrimaryButton>
       </Section>
+
+      <Button
+        onClick={onRequestOTP}
+        disabled={!isValidPhoneNumber || isLoading}
+      >
+        {isLoading ? '발송 중...' : '연락처 인증'}
+      </Button>
 
       {/* 구분선 */}
       <Divider>
@@ -73,15 +82,15 @@ export function LoginStep({
 
       {/* SNS 로그인 섹션 */}
       <Section>
-        <SectionTitle>SNS 로그인</SectionTitle>
-        <SocialButton $provider="kakao" onClick={() => onSocialLogin('kakao')}>
+        <SectionLabel>SNS 로그인</SectionLabel>
+        <Button variant="kakao" onClick={() => onSocialLogin('kakao')}>
           <KakaoIcon />
           카카오로 시작하기
-        </SocialButton>
-        <SocialButton $provider="naver" onClick={() => onSocialLogin('naver')}>
+        </Button>
+        <Button variant="naver" onClick={() => onSocialLogin('naver')}>
           <NaverIcon />
           네이버로 시작하기
-        </SocialButton>
+        </Button>
       </Section>
     </StepContent>
   );
@@ -113,29 +122,41 @@ function NaverIcon() {
 
 // Styled Components
 const StepContent = tw.div`
-  p-5
+  px-5
+  pb-5
   bg-white
   flex
   flex-col
-  gap-4
+  gap-5
+`;
+
+const TopSpacer = tw.div`
+  h-3
+`;
+
+const Title = tw.h2`
+  text-fg-neutral
+  text-[21px]
+  font-bold
+  leading-7
 `;
 
 const Section = tw.div`
   flex
   flex-col
-  gap-3
+  gap-2
 `;
 
-const SectionTitle = tw.h3`
-  text-fg-neutral
-  text-base
-  font-semibold
+const SectionLabel = tw.p`
+  text-fg-muted
+  text-[15px]
+  font-normal
   leading-5
 `;
 
 const PhoneInput = tw.input`
-  h-12
-  px-4
+  h-[44px]
+  px-3
   bg-bg-field
   rounded-xl
   outline
@@ -143,33 +164,16 @@ const PhoneInput = tw.input`
   outline-offset-[-1px]
   outline-[var(--stroke-neutral)]
   text-fg-neutral
-  text-base
+  text-[16.5px]
   font-normal
-  placeholder:text-fg-muted
+  placeholder:text-fg-placeholder
   focus:outline-[var(--stroke-primary)]
-`;
-
-const PrimaryButton = tw.button`
-  w-full
-  h-12
-  px-4
-  bg-bg-neutral-solid
-  rounded-xl
-  text-fg-on-surface
-  text-base
-  font-medium
-  leading-5
-  hover:opacity-90
-  transition-opacity
-  disabled:opacity-50
-  disabled:cursor-not-allowed
 `;
 
 const Divider = tw.div`
   flex
   items-center
-  gap-4
-  py-2
+  gap-3
 `;
 
 const DividerLine = tw.div`
@@ -180,26 +184,8 @@ const DividerLine = tw.div`
 
 const DividerText = tw.span`
   text-fg-muted
-  text-sm
-  font-medium
-`;
-
-const SocialButton = tw.button<{ $provider: 'kakao' | 'naver' }>`
-  w-full
-  h-12
-  px-4
-  rounded-xl
-  flex
-  items-center
-  justify-center
-  gap-2
-  font-medium
-  transition-opacity
-  hover:opacity-90
-  ${({ $provider }) =>
-    $provider === 'kakao'
-      ? 'bg-[#FEE500] text-[#191919]'
-      : 'bg-[#03C75A] text-white'}
+  text-[15px]
+  font-normal
 `;
 
 const ErrorMessage = tw.p`

--- a/apps/shop/src/components/auth/OTPStep.tsx
+++ b/apps/shop/src/components/auth/OTPStep.tsx
@@ -5,21 +5,19 @@
  *
  * Usage:
  * <OTPStep
- *   phoneNumber={phoneNumber}
  *   otpCode={otpCode}
  *   onOtpChange={handleOtpChange}
  *   onVerify={handleVerifyOTP}
- *   onResend={handleResendOTP}
- *   onBack={handleBack}
  *   countdown={countdown}
  *   isLoading={isLoading}
  *   error={error}
  * />
  */
 
-import { ArrowLeft } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import tw from 'tailwind-styled-components';
+
+import { Button } from '@/components/common';
 
 export interface OTPStepProps {
   phoneNumber: string;
@@ -34,28 +32,22 @@ export interface OTPStepProps {
 }
 
 export function OTPStep({
-  phoneNumber,
   otpCode,
   onOtpChange,
   onVerify,
-  onResend,
-  onBack,
   countdown,
   isLoading,
   error,
 }: OTPStepProps) {
-  const otpInputRefs = useRef<(HTMLInputElement | null)[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const otpValue = otpCode.join('');
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      otpInputRefs.current[0]?.focus();
+      inputRef.current?.focus();
     }, 100);
     return () => clearTimeout(timer);
   }, []);
-
-  const maskedPhone = phoneNumber
-    ? `${phoneNumber.slice(0, 3)}****${phoneNumber.slice(-4)}`
-    : '';
 
   const formatCountdown = (seconds: number) => {
     const min = Math.floor(seconds / 60);
@@ -63,192 +55,109 @@ export function OTPStep({
     return `${min}:${sec.toString().padStart(2, '0')}`;
   };
 
-  const handleOtpInputChange = (index: number, value: string) => {
-    if (!/^\d*$/.test(value)) return;
-
-    const newOtp = [...otpCode];
-    newOtp[index] = value.slice(-1);
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.replace(/\D/g, '').slice(0, 6);
+    const newOtp = value.split('').concat(Array(6).fill('')).slice(0, 6);
     onOtpChange(newOtp);
-
-    if (value && index < 5) {
-      otpInputRefs.current[index + 1]?.focus();
-    }
-  };
-
-  const handleOtpKeyDown = (
-    index: number,
-    e: React.KeyboardEvent<HTMLInputElement>
-  ) => {
-    if (e.key === 'Backspace' && !otpCode[index] && index > 0) {
-      otpInputRefs.current[index - 1]?.focus();
-    }
   };
 
   return (
-    <>
-      <OTPHeader>
-        <BackButton onClick={onBack}>
-          <ArrowLeft size={20} />
-        </BackButton>
-        <OTPHeaderTitle>인증번호 입력</OTPHeaderTitle>
-        <BackButtonPlaceholder />
-      </OTPHeader>
+    <StepContent>
+      {/* 상단 라운드 여백 */}
+      <TopSpacer />
 
-      <StepContent>
-        <OTPDescription>
-          {maskedPhone}로 발송된 인증번호를 입력해주세요
-        </OTPDescription>
+      {/* 타이틀 */}
+      <Title>인증번호를 입력해 주세요.</Title>
 
-        <OTPInputContainer>
-          {otpCode.map((digit, index) => (
-            <OTPDigitInput
-              key={index}
-              ref={el => {
-                otpInputRefs.current[index] = el;
-              }}
-              type="tel"
-              inputMode="numeric"
-              maxLength={1}
-              value={digit}
-              onChange={e => handleOtpInputChange(index, e.target.value)}
-              onKeyDown={e => handleOtpKeyDown(index, e)}
-            />
-          ))}
-        </OTPInputContainer>
-
+      {/* 인증번호 입력 섹션 */}
+      <Section>
+        <SectionLabel>인증번호</SectionLabel>
+        <InputWrapper>
+          <OTPInput
+            ref={inputRef}
+            type="tel"
+            inputMode="numeric"
+            placeholder="숫자만 입력해 주세요."
+            value={otpValue}
+            onChange={handleInputChange}
+            maxLength={6}
+          />
+          <TimerText>{formatCountdown(countdown)}</TimerText>
+        </InputWrapper>
         {error && <ErrorMessage>{error}</ErrorMessage>}
+      </Section>
 
-        <TimerContainer>
-          <TimerText>{formatCountdown(countdown)} 남음</TimerText>
-          <ResendButton onClick={onResend} disabled={countdown > 0}>
-            재발송
-          </ResendButton>
-        </TimerContainer>
-      </StepContent>
-
-      <StepFooter>
-        <PrimaryButton
-          onClick={onVerify}
-          disabled={otpCode.join('').length !== 6 || isLoading}
-        >
-          {isLoading ? '확인 중...' : '확인'}
-        </PrimaryButton>
-      </StepFooter>
-    </>
+      <Button onClick={onVerify} disabled={otpValue.length !== 6 || isLoading}>
+        {isLoading ? '확인 중...' : '확인'}
+      </Button>
+    </StepContent>
   );
 }
 
 // Styled Components
-const OTPHeader = tw.div`
-  px-5
-  py-4
-  bg-white
-  flex
-  items-center
-  justify-between
-`;
-
-const BackButton = tw.button`
-  w-10
-  h-10
-  flex
-  items-center
-  justify-center
-  text-fg-neutral
-  hover:bg-bg-neutral-subtle
-  rounded-xl
-  transition-colors
-`;
-
-const BackButtonPlaceholder = tw.div`
-  w-10
-  h-10
-`;
-
-const OTPHeaderTitle = tw.h2`
-  text-fg-neutral
-  text-lg
-  font-bold
-`;
-
 const StepContent = tw.div`
-  p-5
+  px-5
+  pb-5
   bg-white
   flex
   flex-col
-  gap-4
+  gap-5
 `;
 
-const StepFooter = tw.div`
-  p-5
-  bg-white
-  border-t
-  border-[var(--stroke-neutral)]
+const TopSpacer = tw.div`
+  h-3
 `;
 
-const OTPDescription = tw.p`
-  text-fg-muted
-  text-sm
-  text-center
-`;
-
-const OTPInputContainer = tw.div`
-  flex
-  gap-2
-  justify-center
-  py-4
-`;
-
-const OTPDigitInput = tw.input`
-  w-12
-  h-14
-  text-center
-  text-2xl
+const Title = tw.h2`
+  text-fg-neutral
+  text-[21px]
   font-bold
+  leading-7
+`;
+
+const Section = tw.div`
+  flex
+  flex-col
+  gap-2
+`;
+
+const SectionLabel = tw.p`
+  text-fg-muted
+  text-[15px]
+  font-normal
+  leading-5
+`;
+
+const InputWrapper = tw.div`
+  h-[44px]
+  px-3
   bg-bg-field
   rounded-xl
   outline
   outline-1
   outline-offset-[-1px]
   outline-[var(--stroke-neutral)]
-  text-fg-neutral
-  focus:outline-[var(--stroke-primary)]
-`;
-
-const TimerContainer = tw.div`
   flex
   items-center
-  justify-center
-  gap-3
+  gap-2
+  focus-within:outline-[var(--stroke-primary)]
+`;
+
+const OTPInput = tw.input`
+  flex-1
+  bg-transparent
+  text-fg-neutral
+  text-[16.5px]
+  font-normal
+  placeholder:text-fg-placeholder
+  outline-none
 `;
 
 const TimerText = tw.span`
   text-fg-muted
-  text-sm
-`;
-
-const ResendButton = tw.button`
-  text-fg-primary
-  text-sm
-  font-medium
-  disabled:text-fg-muted
-  disabled:cursor-not-allowed
-`;
-
-const PrimaryButton = tw.button`
-  w-full
-  h-12
-  px-4
-  bg-bg-neutral-solid
-  rounded-xl
-  text-fg-on-surface
-  text-base
-  font-medium
-  leading-5
-  hover:opacity-90
-  transition-opacity
-  disabled:opacity-50
-  disabled:cursor-not-allowed
+  text-[16.5px]
+  font-normal
+  shrink-0
 `;
 
 const ErrorMessage = tw.p`

--- a/apps/shop/src/components/common/Button.tsx
+++ b/apps/shop/src/components/common/Button.tsx
@@ -1,0 +1,118 @@
+/**
+ * Button - 공통 버튼 컴포넌트
+ *
+ * 다양한 variant와 size를 지원하는 버튼 컴포넌트입니다.
+ *
+ * Usage:
+ * <Button onClick={handleClick}>확인</Button>
+ * <Button variant="kakao" onClick={handleKakao}><KakaoIcon />카카오로 시작하기</Button>
+ * <Button variant="naver" onClick={handleNaver}><NaverIcon />네이버로 시작하기</Button>
+ */
+
+import { ButtonHTMLAttributes, forwardRef } from 'react';
+import tw from 'tailwind-styled-components';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /** 버튼 스타일 variant */
+  variant?: 'primary' | 'kakao' | 'naver';
+  /** 버튼 크기 */
+  size?: 'medium' | 'large';
+}
+
+/**
+ * Usage:
+ * <Button onClick={handleClick}>확인</Button>
+ * <Button variant="kakao"><KakaoIcon />카카오로 시작하기</Button>
+ * <Button disabled>비활성</Button>
+ */
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ variant = 'primary', size = 'large', children, ...props }, ref) => {
+    if (variant === 'kakao') {
+      return (
+        <KakaoButton ref={ref} $size={size} {...props}>
+          {children}
+        </KakaoButton>
+      );
+    }
+
+    if (variant === 'naver') {
+      return (
+        <NaverButton ref={ref} $size={size} {...props}>
+          {children}
+        </NaverButton>
+      );
+    }
+
+    return (
+      <PrimaryButton ref={ref} $size={size} {...props}>
+        {children}
+      </PrimaryButton>
+    );
+  }
+);
+
+Button.displayName = 'Button';
+
+// Styled Components
+const PrimaryButton = tw.button<{ $size: 'medium' | 'large' }>`
+  w-full
+  px-4
+  rounded-xl
+  flex
+  items-center
+  justify-center
+  gap-1
+  text-[16.5px]
+  font-medium
+  leading-[22px]
+  transition-colors
+  hover:opacity-90
+  disabled:cursor-not-allowed
+  bg-bg-neutral-solid
+  text-fg-on-surface
+  disabled:bg-bg-disabled
+  disabled:text-fg-disabled
+  ${({ $size }) => ($size === 'large' ? 'h-[52px]' : 'h-[44px]')}
+`;
+
+const KakaoButton = tw.button<{ $size: 'medium' | 'large' }>`
+  w-full
+  px-4
+  rounded-xl
+  flex
+  items-center
+  justify-center
+  gap-1
+  text-[16.5px]
+  font-medium
+  leading-[22px]
+  transition-colors
+  hover:opacity-90
+  disabled:cursor-not-allowed
+  bg-[#FEE500]
+  text-fg-neutral
+  disabled:bg-bg-disabled
+  disabled:text-fg-disabled
+  ${({ $size }) => ($size === 'large' ? 'h-[52px]' : 'h-[44px]')}
+`;
+
+const NaverButton = tw.button<{ $size: 'medium' | 'large' }>`
+  w-full
+  px-4
+  rounded-xl
+  flex
+  items-center
+  justify-center
+  gap-1
+  text-[16.5px]
+  font-medium
+  leading-[22px]
+  transition-colors
+  hover:opacity-90
+  disabled:cursor-not-allowed
+  bg-[#02C75A]
+  text-white
+  disabled:bg-bg-disabled
+  disabled:text-fg-disabled
+  ${({ $size }) => ($size === 'large' ? 'h-[52px]' : 'h-[44px]')}
+`;

--- a/apps/shop/src/components/common/index.ts
+++ b/apps/shop/src/components/common/index.ts
@@ -1,0 +1,2 @@
+export { Button } from './Button';
+export type { ButtonProps } from './Button';


### PR DESCRIPTION

<img width="456" height="407" alt="image" src="https://github.com/user-attachments/assets/bebc2907-268b-4409-a60f-1d75b8e37073" />


<img width="558" height="246" alt="image" src="https://github.com/user-attachments/assets/23aaca78-28c0-487c-a81a-f631894bbaa0" />

## Summary
- 로그인 바텀시트(LoginStep, OTPStep) Figma 디자인 반영
- 공통 Button 컴포넌트 추가 (`apps/shop/src/components/common/Button.tsx`)
- 비활성 버튼 스타일: opacity → 별도 disabled 색상 적용

## 변경 사항

### LoginBottomSheet
- Handle(드래그 인디케이터) 제거

### LoginStep
| 항목 | 이전 | 이후 |
|------|------|------|
| 타이틀 | 없음 | "로그인" (Bold, 21px) |
| placeholder | "01012345678" | "연락처를 입력해 주세요." |
| 입력필드 높이 | 48px | 44px |
| 버튼 높이 | 48px | 52px |
| 전체 gap | 16px | 20px |
| 네이버 색상 | #03C75A | #02C75A |

### OTPStep
| 항목 | 이전 | 이후 |
|------|------|------|
| 타이틀 | 헤더 "인증번호 입력" | "인증번호를 입력해 주세요." |
| 입력 방식 | 6개 개별 박스 | 단일 입력 필드 |
| 타이머 | 별도 영역 + 재발송 버튼 | 입력 필드 오른쪽 |
| 헤더/뒤로가기 | 있음 | 제거됨 |

### 공통 Button 컴포넌트
```tsx
// 사용법
<Button>확인</Button>
<Button variant="kakao"><KakaoIcon />카카오로 시작하기</Button>
<Button variant="naver"><NaverIcon />네이버로 시작하기</Button>
<Button disabled>비활성</Button>
<Button size="medium">작은 버튼 (44px)</Button>
```

## Test plan
- [ ] 로그인 바텀시트 열기 확인
- [ ] 연락처 입력 → 연락처 인증 버튼 활성화 확인
- [ ] 비활성 버튼 스타일 확인 (연한 회색 배경 + 회색 텍스트)
- [ ] 카카오/네이버 버튼 클릭 확인
- [ ] OTP 입력 화면 전환 확인
- [ ] OTP 6자리 입력 → 확인 버튼 활성화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)