### PR TITLE
FEAT: 캠페인 상세 페이지 Figma 디자인 적용

### DIFF
--- a/apps/shop/src/components/campaign/CampaignInfo.tsx
+++ b/apps/shop/src/components/campaign/CampaignInfo.tsx
@@ -1,0 +1,99 @@
+/**
+ * CampaignInfo - 캠페인 정보 영역 컴포넌트
+ *
+ * 캠페인 상태 뱃지, 제목, 기간을 중앙 정렬로 표시합니다.
+ *
+ * Usage:
+ * <CampaignInfo
+ *   title="이번 크리스마스는 고요하우스"
+ *   startAt={new Date()}
+ *   endAt={new Date()}
+ * />
+ */
+
+import { Clock } from 'lucide-react';
+import tw from 'tailwind-styled-components';
+
+import {
+  type CampaignStatusType,
+  formatShortDate,
+  getCampaignStatus,
+} from '@/shared';
+
+export interface CampaignInfoProps {
+  /** 캠페인 제목 */
+  title: string;
+  /** 캠페인 시작일 */
+  startAt: Date | string;
+  /** 캠페인 종료일 */
+  endAt: Date | string;
+}
+
+export function CampaignInfo({ title, startAt, endAt }: CampaignInfoProps) {
+  const status = getCampaignStatus(startAt, endAt);
+
+  return (
+    <Container>
+      <StatusBadge $type={status.type}>
+        <Clock size={16} />
+        <BadgeText>{status.label}</BadgeText>
+      </StatusBadge>
+      <TitleWrapper>
+        <Title>{title}</Title>
+        <Period>
+          {formatShortDate(startAt)} ~ {formatShortDate(endAt)}
+        </Period>
+      </TitleWrapper>
+    </Container>
+  );
+}
+
+// Styled Components
+const Container = tw.div`
+  flex
+  flex-col
+  items-center
+  gap-3
+  px-5
+  py-8
+`;
+
+const StatusBadge = tw.div<{ $type: CampaignStatusType }>`
+  h-5
+  px-1
+  rounded-lg
+  inline-flex
+  items-center
+  gap-0.5
+  text-fg-neutral-inverted
+  ${({ $type }) =>
+    $type === 'upcoming' ? 'bg-bg-neutral-solid' : 'bg-bg-primary-solid'}
+`;
+
+const BadgeText = tw.span`
+  text-xs
+  font-medium
+  leading-4
+  px-0.5
+`;
+
+const TitleWrapper = tw.div`
+  flex
+  flex-col
+  items-center
+  gap-1
+`;
+
+const Title = tw.h1`
+  text-[21px]
+  font-bold
+  leading-7
+  text-fg-neutral
+  text-center
+`;
+
+const Period = tw.p`
+  text-[13.5px]
+  leading-[18px]
+  text-fg-neutral
+`;

--- a/apps/shop/src/components/campaign/CampaignList.tsx
+++ b/apps/shop/src/components/campaign/CampaignList.tsx
@@ -8,58 +8,23 @@
  */
 
 import { Link } from '@tanstack/react-router';
-import dayjs from 'dayjs';
-import 'dayjs/locale/ko';
 import { Bell } from 'lucide-react';
 import { toast } from 'sonner';
 import tw from 'tailwind-styled-components';
 
 import { ChevronRightIcon } from '@/components/icons';
 import {
+  type CampaignStatusType,
   formatDateWithDay,
   formatPrice,
   formatShortDate,
+  getCampaignStatus,
+  isProductUpcoming,
   trpc,
 } from '@/shared';
 
-dayjs.locale('ko');
-
 export interface CampaignListProps {
   slug: string;
-}
-
-type CampaignStatusType = 'upcoming' | 'ongoing' | 'ending';
-
-/** 캠페인 상태 계산 */
-function getCampaignStatus(
-  startAt: Date | string,
-  endAt: Date | string
-): { type: CampaignStatusType; label: string } {
-  const now = dayjs();
-  const start = dayjs(startAt);
-  const end = dayjs(endAt);
-
-  if (now.isBefore(start)) {
-    return { type: 'upcoming', label: '오픈 예정' };
-  }
-
-  const daysUntilEnd = end.diff(now, 'day') + 1;
-
-  if (daysUntilEnd <= 3) {
-    return { type: 'ending', label: `${daysUntilEnd}일 후 종료` };
-  }
-
-  return { type: 'ongoing', label: `${daysUntilEnd}일 후 종료` };
-}
-
-/** 상품 오픈 예정 여부 체크 */
-function isProductUpcoming(
-  saleStartAt: Date | string | null | undefined,
-  campaignStartAt: Date | string
-): boolean {
-  const now = dayjs();
-  const startDate = dayjs(saleStartAt ?? campaignStartAt);
-  return now.isBefore(startDate);
 }
 
 // ============================================================================

--- a/apps/shop/src/components/campaign/FloatingDateButton.tsx
+++ b/apps/shop/src/components/campaign/FloatingDateButton.tsx
@@ -1,0 +1,76 @@
+/**
+ * FloatingDateButton - 플로팅 날짜 선택 버튼 컴포넌트
+ *
+ * 캠페인 상세 페이지 하단에 고정되는 날짜 표시 버튼입니다.
+ *
+ * Usage:
+ * <FloatingDateButton
+ *   startAt={new Date()}
+ *   endAt={new Date()}
+ *   onClick={() => {}}
+ * />
+ */
+
+import { Calendar } from 'lucide-react';
+import tw from 'tailwind-styled-components';
+
+import { formatDateWithDay } from '@/shared';
+
+export interface FloatingDateButtonProps {
+  /** 캠페인 시작일 */
+  startAt: Date | string;
+  /** 캠페인 종료일 */
+  endAt: Date | string;
+  /** 클릭 핸들러 */
+  onClick?: () => void;
+}
+
+export function FloatingDateButton({
+  startAt,
+  endAt,
+  onClick,
+}: FloatingDateButtonProps) {
+  return (
+    <Container>
+      <Button onClick={onClick}>
+        <Calendar size={22} />
+        <DateText>
+          {formatDateWithDay(startAt)} ~ {formatDateWithDay(endAt)}
+        </DateText>
+      </Button>
+    </Container>
+  );
+}
+
+// Styled Components
+const Container = tw.div`
+  fixed
+  bottom-8
+  left-1/2
+  -translate-x-1/2
+  z-50
+`;
+
+const Button = tw.button`
+  h-11
+  px-3
+  rounded-full
+  bg-white
+  border
+  border-stroke-neutral
+  shadow-[0px_8px_32px_0px_rgba(0,0,0,0.12),0px_0px_2px_0px_rgba(0,0,0,0.12)]
+  flex
+  items-center
+  gap-1
+  text-fg-neutral
+  hover:bg-gray-50
+  transition-colors
+`;
+
+const DateText = tw.span`
+  text-[16.5px]
+  font-medium
+  leading-[22px]
+  px-1
+  whitespace-nowrap
+`;

--- a/apps/shop/src/components/campaign/ProductCard.tsx
+++ b/apps/shop/src/components/campaign/ProductCard.tsx
@@ -1,0 +1,140 @@
+/**
+ * ProductCard - 캠페인 상세 상품 카드 컴포넌트
+ *
+ * 캠페인 상세 페이지에서 사용되는 상품 카드입니다.
+ * 썸네일, 상품명, 원가, 할인율, 할인가를 표시합니다.
+ *
+ * Usage:
+ * <ProductCard
+ *   thumbnail="/image.jpg"
+ *   name="고요하우스 1001호"
+ *   originalPrice={29000}
+ *   price={26890}
+ * />
+ */
+
+import { Link } from '@tanstack/react-router';
+import tw from 'tailwind-styled-components';
+
+import { calculateDiscountRate, formatPriceExact } from '@/shared';
+
+export interface ProductCardProps {
+  /** 상품 ID */
+  id: number;
+  /** 판매 ID (상품 상세 페이지 이동용) */
+  saleId: number;
+  /** 상품 썸네일 URL */
+  thumbnail: string | null;
+  /** 상품명 */
+  name: string;
+  /** 원가 */
+  originalPrice: number;
+  /** 할인가 */
+  price: number;
+}
+
+export function ProductCard({
+  saleId,
+  thumbnail,
+  name,
+  originalPrice,
+  price,
+}: ProductCardProps) {
+  const discountRate = calculateDiscountRate(originalPrice, price);
+  const hasDiscount = discountRate > 0;
+
+  return (
+    <Link to="/sale/$saleId" params={{ saleId: String(saleId) }}>
+      <CardContainer>
+        <ThumbnailWrapper>
+          <Thumbnail
+            src={thumbnail || '/default-product.png'}
+            alt={name}
+            loading="lazy"
+          />
+        </ThumbnailWrapper>
+        <InfoWrapper>
+          <ProductName>{name}</ProductName>
+          <PriceWrapper>
+            {hasDiscount && (
+              <OriginalPrice>{formatPriceExact(originalPrice)}</OriginalPrice>
+            )}
+            <DiscountRow>
+              {hasDiscount && <DiscountRate>{discountRate}%</DiscountRate>}
+              <Price>{formatPriceExact(price)}</Price>
+            </DiscountRow>
+          </PriceWrapper>
+        </InfoWrapper>
+      </CardContainer>
+    </Link>
+  );
+}
+
+// Styled Components
+const CardContainer = tw.div`
+  flex
+  flex-col
+  gap-2
+  cursor-pointer
+`;
+
+const ThumbnailWrapper = tw.div`
+  relative
+  aspect-square
+  w-full
+  rounded-xl
+  overflow-hidden
+  border
+  border-[rgba(0,0,0,0.05)]
+  bg-bg-neutral-subtle
+`;
+
+const Thumbnail = tw.img`
+  w-full
+  h-full
+  object-cover
+`;
+
+const InfoWrapper = tw.div`
+  flex
+  flex-col
+  gap-1
+`;
+
+const ProductName = tw.p`
+  text-[15px]
+  leading-5
+  text-fg-neutral
+`;
+
+const PriceWrapper = tw.div`
+  flex
+  flex-col
+`;
+
+const OriginalPrice = tw.p`
+  text-xs
+  leading-4
+  text-fg-disabled
+  line-through
+`;
+
+const DiscountRow = tw.div`
+  flex
+  items-center
+  gap-1
+`;
+
+const DiscountRate = tw.span`
+  text-lg
+  font-bold
+  leading-6
+  text-fg-critical
+`;
+
+const Price = tw.span`
+  text-lg
+  font-bold
+  leading-6
+  text-fg-neutral
+`;

--- a/apps/shop/src/components/campaign/ProductGrid.tsx
+++ b/apps/shop/src/components/campaign/ProductGrid.tsx
@@ -1,0 +1,59 @@
+/**
+ * ProductGrid - 캠페인 상품 그리드 컴포넌트
+ *
+ * 캠페인 상세 페이지에서 상품 목록을 그리드로 표시합니다.
+ * 모바일 1열, sm 이상에서 2열 그리드로 반응형 처리됩니다.
+ *
+ * Usage:
+ * <ProductGrid products={products} />
+ */
+
+import tw from 'tailwind-styled-components';
+
+import { ProductCard, type ProductCardProps } from './ProductCard';
+
+export interface ProductGridProps {
+  /** 상품 목록 */
+  products: ProductCardProps[];
+}
+
+export function ProductGrid({ products }: ProductGridProps) {
+  if (products.length === 0) {
+    return (
+      <EmptyState>
+        <EmptyText>등록된 상품이 없습니다.</EmptyText>
+      </EmptyState>
+    );
+  }
+
+  return (
+    <GridContainer>
+      {products.map(product => (
+        <ProductCard key={product.id} {...product} />
+      ))}
+    </GridContainer>
+  );
+}
+
+// Styled Components
+const GridContainer = tw.div`
+  grid
+  grid-cols-1
+  sm:grid-cols-2
+  gap-x-3
+  gap-y-5
+  px-5
+`;
+
+const EmptyState = tw.div`
+  flex
+  justify-center
+  items-center
+  py-16
+  px-5
+`;
+
+const EmptyText = tw.p`
+  text-fg-muted
+  text-lg
+`;

--- a/apps/shop/src/index.css
+++ b/apps/shop/src/index.css
@@ -10,6 +10,7 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background: var(--bg-layer-base, #F4F4F5);
 }
 
 code {

--- a/apps/shop/src/routes/i.$slug.c.$campaignId.tsx
+++ b/apps/shop/src/routes/i.$slug.c.$campaignId.tsx
@@ -1,53 +1,178 @@
+/**
+ * 캠페인 상세 페이지
+ *
+ * 부모 레이아웃(i.$slug.tsx)에서 HeaderLayout 헤더를 상속받음
+ * 캠페인 정보, 상품 목록, 플로팅 날짜 버튼을 표시합니다.
+ */
+
 import { createFileRoute } from '@tanstack/react-router';
+import { Suspense } from 'react';
+import { toast } from 'sonner';
 import tw from 'tailwind-styled-components';
+
+import { CampaignInfo } from '@/components/campaign/CampaignInfo';
+import { FloatingDateButton } from '@/components/campaign/FloatingDateButton';
+import { ProductGrid } from '@/components/campaign/ProductGrid';
+import { trpc } from '@/shared';
 
 export const Route = createFileRoute('/i/$slug/c/$campaignId')({
   component: CampaignDetailPage,
 });
 
-/**
- * 캠페인 상세 페이지
- * 부모 레이아웃(i.$slug.tsx)에서 HeaderLayout 헤더를 상속받음
- */
 function CampaignDetailPage() {
   const { slug, campaignId } = Route.useParams();
 
   return (
-    <ContentContainer>
-      <Content>
-        <Title>캠페인 상세 페이지</Title>
-        <Info>인플루언서 Slug: {slug}</Info>
-        <Info>캠페인 ID: {campaignId}</Info>
-        <Info>TODO: 캠페인 상세 API 연동 필요</Info>
-      </Content>
-    </ContentContainer>
+    <Suspense fallback={<CampaignDetailSkeleton />}>
+      <CampaignDetailContent slug={slug} campaignId={Number(campaignId)} />
+    </Suspense>
+  );
+}
+
+interface CampaignDetailContentProps {
+  slug: string;
+  campaignId: number;
+}
+
+function CampaignDetailContent({
+  slug,
+  campaignId,
+}: CampaignDetailContentProps) {
+  const [data] = trpc.shopInfluencer.getCampaignDetail.useSuspenseQuery({
+    slug,
+    campaignId,
+  });
+
+  const handleDateButtonClick = () => {
+    toast.info('날짜 선택 기능 준비 중입니다');
+  };
+
+  return (
+    <Container>
+      <CampaignInfo
+        title={data.title}
+        startAt={data.startAt}
+        endAt={data.endAt}
+      />
+      <ProductGrid
+        products={data.products.map(product => ({
+          id: product.id,
+          saleId: product.saleId,
+          thumbnail: product.thumbnail,
+          name: product.name,
+          originalPrice: product.originalPrice,
+          price: product.price,
+        }))}
+      />
+      <FloatingDateButton
+        startAt={data.startAt}
+        endAt={data.endAt}
+        onClick={handleDateButtonClick}
+      />
+      <BottomSpacer />
+    </Container>
+  );
+}
+
+function CampaignDetailSkeleton() {
+  return (
+    <Container>
+      <SkeletonInfoWrapper>
+        <SkeletonBadge />
+        <SkeletonTitle />
+        <SkeletonPeriod />
+      </SkeletonInfoWrapper>
+      <SkeletonGrid>
+        {[1, 2, 3, 4].map(index => (
+          <SkeletonCard key={index}>
+            <SkeletonThumbnail />
+            <SkeletonProductName />
+            <SkeletonPrice />
+          </SkeletonCard>
+        ))}
+      </SkeletonGrid>
+    </Container>
   );
 }
 
 // Styled Components
-const ContentContainer = tw.div`
+const Container = tw.div`
+  pb-8
+`;
+
+const BottomSpacer = tw.div`
+  h-20
+`;
+
+// Skeleton Components
+const SkeletonInfoWrapper = tw.div`
+  flex
+  flex-col
+  items-center
+  gap-3
   px-5
-  py-6
+  py-8
 `;
 
-const Content = tw.div`
-  text-center
-  p-8
-  bg-white
+const SkeletonBadge = tw.div`
+  w-24
+  h-5
+  bg-bg-neutral-subtle
+  rounded-lg
+  animate-pulse
+`;
+
+const SkeletonTitle = tw.div`
+  w-64
+  h-7
+  bg-bg-neutral-subtle
+  rounded
+  animate-pulse
+`;
+
+const SkeletonPeriod = tw.div`
+  w-40
+  h-5
+  bg-bg-neutral-subtle
+  rounded
+  animate-pulse
+`;
+
+const SkeletonGrid = tw.div`
+  grid
+  grid-cols-1
+  sm:grid-cols-2
+  gap-x-3
+  gap-y-5
+  px-5
+`;
+
+const SkeletonCard = tw.div`
+  flex
+  flex-col
+  gap-2
+`;
+
+const SkeletonThumbnail = tw.div`
+  aspect-square
+  w-full
+  bg-bg-neutral-subtle
   rounded-xl
-  border
-  border-[var(--stroke-neutral)]
+  animate-pulse
 `;
 
-const Title = tw.h1`
-  text-xl
-  font-bold
-  text-fg-neutral
-  mb-4
+const SkeletonProductName = tw.div`
+  w-full
+  h-5
+  bg-bg-neutral-subtle
+  rounded
+  animate-pulse
 `;
 
-const Info = tw.p`
-  text-fg-muted
-  mb-2
-  text-sm
+const SkeletonPrice = tw.div`
+  w-24
+  h-6
+  bg-bg-neutral-subtle
+  rounded
+  animate-pulse
 `;

--- a/apps/shop/src/shared/components/HeaderLayout.tsx
+++ b/apps/shop/src/shared/components/HeaderLayout.tsx
@@ -43,7 +43,7 @@ export function HeaderLayout({
 
 const Container = tw.main`
   min-h-screen
-  bg-bg-layer-base
+  bg-white
   max-w-[600px]
   mx-auto
 `;

--- a/apps/shop/src/shared/utils/campaign.ts
+++ b/apps/shop/src/shared/utils/campaign.ts
@@ -1,0 +1,67 @@
+/**
+ * Campaign Utils - 캠페인 관련 유틸리티
+ *
+ * 캠페인 상태 계산, 할인율 계산 등의 함수를 제공합니다.
+ *
+ * Usage:
+ * import { getCampaignStatus, calculateDiscountRate } from '@/shared';
+ */
+
+import dayjs from 'dayjs';
+import 'dayjs/locale/ko';
+
+dayjs.locale('ko');
+
+export type CampaignStatusType = 'upcoming' | 'ongoing';
+
+export interface CampaignStatus {
+  type: CampaignStatusType;
+  label: string;
+}
+
+/**
+ * 캠페인 상태 계산
+ * - upcoming: 오픈 예정
+ * - ongoing: 진행 중 (N일 후 종료)
+ */
+export function getCampaignStatus(
+  startAt: Date | string,
+  endAt: Date | string
+): CampaignStatus {
+  const now = dayjs();
+  const start = dayjs(startAt);
+  const end = dayjs(endAt);
+
+  if (now.isBefore(start)) {
+    return { type: 'upcoming', label: '오픈 예정' };
+  }
+
+  const daysUntilEnd = end.diff(now, 'day') + 1;
+  return { type: 'ongoing', label: `${daysUntilEnd}일 후 종료` };
+}
+
+/**
+ * 할인율 계산
+ * @returns 할인율 (정수, 0이면 할인 없음)
+ */
+export function calculateDiscountRate(
+  originalPrice: number,
+  price: number
+): number {
+  if (originalPrice <= 0 || price >= originalPrice) {
+    return 0;
+  }
+  return Math.round(((originalPrice - price) / originalPrice) * 100);
+}
+
+/**
+ * 상품 오픈 예정 여부 체크
+ */
+export function isProductUpcoming(
+  saleStartAt: Date | string | null | undefined,
+  campaignStartAt: Date | string
+): boolean {
+  const now = dayjs();
+  const startDate = dayjs(saleStartAt ?? campaignStartAt);
+  return now.isBefore(startDate);
+}

--- a/apps/shop/src/shared/utils/index.ts
+++ b/apps/shop/src/shared/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './format';
+export * from './campaign';


### PR DESCRIPTION
## Summary
- 캠페인 상세 페이지 UI를 Figma 디자인에 맞게 구현
- 캠페인 정보 영역 (상태 뱃지, 제목, 기간) 컴포넌트화
- 상품 그리드 (반응형 1열/2열) 및 상품 카드 컴포넌트 추가
- 플로팅 날짜 선택 버튼 구현
- 캠페인 유틸 함수 공통화 및 CampaignList 리팩토링

## Changes
| 파일 | 설명 |
|------|------|
| `shared/utils/campaign.ts` | 캠페인 상태 계산, 할인율 계산 유틸 |
| `components/campaign/CampaignInfo.tsx` | 캠페인 정보 (뱃지, 제목, 기간) |
| `components/campaign/ProductCard.tsx` | 상품 카드 (썸네일, 가격, 할인율) |
| `components/campaign/ProductGrid.tsx` | 반응형 상품 그리드 |
| `components/campaign/FloatingDateButton.tsx` | 플로팅 날짜 버튼 |
| `routes/i.$slug.c.$campaignId.tsx` | 캠페인 상세 페이지 통합 |
| `components/campaign/CampaignList.tsx` | 공통 유틸 사용으로 리팩토링 |
| `index.css`, `HeaderLayout.tsx` | 레이아웃 배경색 조정 |

## Test plan
- [ ] 캠페인 상세 페이지 접속 확인 (`/i/{slug}/c/{campaignId}`)
- [ ] 캠페인 정보 (뱃지, 제목, 기간) 표시 확인
- [ ] 상품 그리드 반응형 (모바일 1열, sm 이상 2열) 확인
- [ ] 상품 카드 할인율 계산 및 표시 확인
- [ ] 플로팅 날짜 버튼 동작 확인
- [ ] 스켈레톤 로딩 UI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)