### PR TITLE
FEAT: 주문 상세 페이지 및 OrderStatusCard 컴파운드 컴포넌트 구현

### DIFF
--- a/apps/shop/src/components/order/AccommodationOrderStatusCard.tsx
+++ b/apps/shop/src/components/order/AccommodationOrderStatusCard.tsx
@@ -1,0 +1,67 @@
+/**
+ * AccommodationOrderStatusCard - 숙박 주문 상태 카드
+ *
+ * 숙박 주문의 상태를 표시하는 컴포넌트입니다.
+ * OrderStatusCard 컴파운드 컴포넌트를 사용합니다.
+ *
+ * Usage:
+ * <AccommodationOrderStatusCard
+ *   data={accommodationOrderData}
+ *   onCancelRequest={() => console.log('취소 신청')}
+ * />
+ */
+
+import { OrderStatusCard, type OrderStatusType } from './OrderStatusCard';
+
+export interface AccommodationOrderData {
+  status: OrderStatusType;
+  statusDescription?: string;
+  accommodation: {
+    thumbnail: string | null;
+    hotelName: string;
+    roomName: string;
+    optionName: string;
+  };
+  checkIn: {
+    date: string;
+    time: string;
+  };
+  checkOut: {
+    date: string;
+    time: string;
+  };
+}
+
+export interface AccommodationOrderStatusCardProps {
+  data: AccommodationOrderData;
+  onCancelRequest: () => void;
+}
+
+export function AccommodationOrderStatusCard({
+  data,
+  onCancelRequest,
+}: AccommodationOrderStatusCardProps) {
+  return (
+    <OrderStatusCard>
+      <OrderStatusCard.Header status={data.status}>
+        {data.statusDescription}
+      </OrderStatusCard.Header>
+      <OrderStatusCard.AccommodationInfo
+        thumbnail={data.accommodation.thumbnail}
+        hotelName={data.accommodation.hotelName}
+        roomName={data.accommodation.roomName}
+        optionName={data.accommodation.optionName}
+      />
+      <OrderStatusCard.Divider />
+      <OrderStatusCard.CheckTime
+        checkIn={data.checkIn}
+        checkOut={data.checkOut}
+      />
+      <OrderStatusCard.Actions>
+        <OrderStatusCard.SubtleButton onClick={onCancelRequest}>
+          취소 신청
+        </OrderStatusCard.SubtleButton>
+      </OrderStatusCard.Actions>
+    </OrderStatusCard>
+  );
+}

--- a/apps/shop/src/components/order/CancelledProductsSection.tsx
+++ b/apps/shop/src/components/order/CancelledProductsSection.tsx
@@ -1,0 +1,199 @@
+/**
+ * CancelledProductsSection - 취소 요청 상품 섹션
+ *
+ * 취소 요청된 상품 목록을 표시하는 컴포넌트입니다.
+ *
+ * Usage:
+ * <CancelledProductsSection
+ *   products={cancelledProducts}
+ *   onWithdraw={() => console.log('취소 철회')}
+ * />
+ */
+
+import { ChevronRight } from 'lucide-react';
+import tw from 'tailwind-styled-components';
+
+import { formatPriceExact } from '@/shared';
+
+export interface CancelledProduct {
+  id: string;
+  thumbnail: string | null;
+  name: string;
+  option: string;
+  price: number;
+  quantity: number;
+}
+
+export interface CancelledProductsSectionProps {
+  products: CancelledProduct[] | undefined;
+  onWithdraw: () => void;
+}
+
+export function CancelledProductsSection({
+  products,
+  onWithdraw,
+}: CancelledProductsSectionProps) {
+  if (!products || products.length === 0) return null;
+
+  return (
+    <Section>
+      <SectionHeader>
+        <SectionTitle>취소요청</SectionTitle>
+        <InlineButton>
+          <InlineButtonText>상세보기</InlineButtonText>
+          <ChevronRight size={20} />
+        </InlineButton>
+      </SectionHeader>
+      <ProductListContainer>
+        {products.map(product => (
+          <ProductItemContainer key={product.id}>
+            <ProductThumbnail
+              src={product.thumbnail || '/default-product.png'}
+              alt={product.name}
+              loading="lazy"
+            />
+            <ProductDetails>
+              <ProductInfo>
+                <ProductName>{product.name}</ProductName>
+                {product.option && (
+                  <ProductOption>{product.option}</ProductOption>
+                )}
+              </ProductInfo>
+              <ProductPriceRow>
+                <ProductPrice>{formatPriceExact(product.price)}</ProductPrice>
+                <ProductQuantity>{product.quantity}개</ProductQuantity>
+              </ProductPriceRow>
+            </ProductDetails>
+          </ProductItemContainer>
+        ))}
+      </ProductListContainer>
+      <ActionContainer>
+        <SubtleButtonStyled onClick={onWithdraw}>취소 철회</SubtleButtonStyled>
+      </ActionContainer>
+    </Section>
+  );
+}
+
+// ============================================================================
+// Styled Components
+// ============================================================================
+
+const Section = tw.section`
+  bg-white
+  p-5
+  flex
+  flex-col
+  gap-5
+`;
+
+const SectionHeader = tw.div`
+  flex
+  items-center
+  justify-between
+`;
+
+const SectionTitle = tw.h3`
+  text-lg
+  font-bold
+  leading-6
+  text-fg-neutral
+`;
+
+const InlineButton = tw.button`
+  flex
+  items-center
+  gap-1
+  text-fg-neutral
+`;
+
+const InlineButtonText = tw.span`
+  text-[15px]
+  leading-5
+`;
+
+const ProductListContainer = tw.div`
+  flex
+  flex-col
+  gap-4
+`;
+
+const ProductItemContainer = tw.div`
+  flex
+  gap-3
+  items-start
+`;
+
+const ProductThumbnail = tw.img`
+  w-[52px]
+  h-[52px]
+  rounded-xl
+  object-cover
+  border
+  border-[rgba(0,0,0,0.05)]
+  flex-shrink-0
+`;
+
+const ProductDetails = tw.div`
+  flex-1
+  flex
+  flex-col
+  gap-1
+`;
+
+const ProductInfo = tw.div`
+  flex
+  flex-col
+`;
+
+const ProductName = tw.p`
+  text-[15px]
+  leading-5
+  text-fg-neutral
+`;
+
+const ProductOption = tw.p`
+  text-[15px]
+  leading-5
+  text-fg-muted
+`;
+
+const ProductPriceRow = tw.div`
+  flex
+  items-baseline
+  gap-1
+`;
+
+const ProductPrice = tw.span`
+  text-lg
+  font-bold
+  leading-6
+  text-fg-neutral
+`;
+
+const ProductQuantity = tw.span`
+  text-[15px]
+  leading-5
+  text-fg-muted
+`;
+
+const ActionContainer = tw.div`
+  flex
+  gap-2
+`;
+
+const SubtleButtonStyled = tw.button`
+  flex-1
+  h-11
+  bg-bg-neutral
+  text-fg-neutral
+  rounded-xl
+  flex
+  items-center
+  justify-center
+  gap-1
+  text-[16.5px]
+  font-medium
+  leading-[22px]
+  hover:opacity-90
+  transition-opacity
+`;

--- a/apps/shop/src/components/order/OrderStatusCard.tsx
+++ b/apps/shop/src/components/order/OrderStatusCard.tsx
@@ -1,0 +1,505 @@
+/**
+ * OrderStatusCard - 주문 상태 카드 컴파운드 컴포넌트
+ *
+ * 주문 상세 페이지에서 주문 상태를 표시하는 컴포넌트입니다.
+ * 숙박/배송 등 다양한 주문 유형에 대응할 수 있는 컴파운드 컴포넌트 패턴으로 구현되었습니다.
+ *
+ * Usage (숙박):
+ * <OrderStatusCard>
+ *   <OrderStatusCard.Header status="PENDING_PAYMENT">
+ *     12월 12일(목)까지 13,000원을 입금해 주세요.
+ *   </OrderStatusCard.Header>
+ *   <OrderStatusCard.AccommodationInfo
+ *     thumbnail="/image.jpg"
+ *     hotelName="인천 월미도 고요하우스"
+ *     roomName="로얄 트윈"
+ *     optionName="3인 패키지"
+ *   />
+ *   <OrderStatusCard.Divider />
+ *   <OrderStatusCard.CheckTime
+ *     checkIn={{ date: "25.12.10(금)", time: "17:00" }}
+ *     checkOut={{ date: "25.12.14(금)", time: "13:00" }}
+ *   />
+ *   <OrderStatusCard.Actions>
+ *     <OrderStatusCard.SolidButton onClick={handleCopy}>
+ *       입금 계좌번호 복사 <Copy size={20} />
+ *     </OrderStatusCard.SolidButton>
+ *   </OrderStatusCard.Actions>
+ * </OrderStatusCard>
+ *
+ * Usage (배송):
+ * <OrderStatusCard>
+ *   <OrderStatusCard.Header status="PAYMENT_COMPLETED" />
+ *   <OrderStatusCard.ProductList>
+ *     <OrderStatusCard.ProductItem
+ *       thumbnail="/image.jpg"
+ *       name="우먼즈 집 재킷"
+ *       option="블랙 / M"
+ *       price={17500}
+ *       quantity={1}
+ *     />
+ *   </OrderStatusCard.ProductList>
+ *   <OrderStatusCard.Actions>
+ *     <OrderStatusCard.SubtleButton>주문취소</OrderStatusCard.SubtleButton>
+ *   </OrderStatusCard.Actions>
+ * </OrderStatusCard>
+ */
+
+import { type ReactNode } from 'react';
+import tw from 'tailwind-styled-components';
+
+import { formatPriceExact } from '@/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** 주문 상태 타입 */
+export const ORDER_STATUS = {
+  // 공통 상태
+  PENDING_PAYMENT: 'PENDING_PAYMENT',
+  PAYMENT_COMPLETED: 'PAYMENT_COMPLETED',
+
+  // 숙박 전용 상태
+  PENDING_RESERVATION: 'PENDING_RESERVATION',
+  RESERVATION_CONFIRMED: 'RESERVATION_CONFIRMED',
+  COMPLETED: 'COMPLETED',
+
+  // 배송 전용 상태
+  PREPARING_SHIPMENT: 'PREPARING_SHIPMENT',
+  SHIPPING: 'SHIPPING',
+  DELIVERED: 'DELIVERED',
+  PURCHASE_CONFIRMED: 'PURCHASE_CONFIRMED',
+
+  // 취소 상태
+  CANCEL_REQUESTED: 'CANCEL_REQUESTED',
+  CANCELLED: 'CANCELLED',
+
+  // 반품 상태 (배송 전용)
+  RETURN_REQUESTED: 'RETURN_REQUESTED',
+  RETURN_COMPLETED: 'RETURN_COMPLETED',
+} as const;
+
+export type OrderStatusType = (typeof ORDER_STATUS)[keyof typeof ORDER_STATUS];
+
+/** 상태별 라벨 */
+const STATUS_LABELS: Record<OrderStatusType, string> = {
+  // 공통
+  PENDING_PAYMENT: '결제대기',
+  PAYMENT_COMPLETED: '결제완료',
+
+  // 숙박
+  PENDING_RESERVATION: '예약대기',
+  RESERVATION_CONFIRMED: '예약확정',
+  COMPLETED: '이용완료',
+
+  // 배송
+  PREPARING_SHIPMENT: '배송준비중',
+  SHIPPING: '배송중',
+  DELIVERED: '배송완료',
+  PURCHASE_CONFIRMED: '구매확정',
+
+  // 취소
+  CANCEL_REQUESTED: '취소요청',
+  CANCELLED: '취소완료',
+
+  // 반품
+  RETURN_REQUESTED: '반품요청',
+  RETURN_COMPLETED: '반품완료',
+};
+
+// ============================================================================
+// Root Component
+// ============================================================================
+
+interface OrderStatusCardProps {
+  children: ReactNode;
+}
+
+function OrderStatusCardRoot({ children }: OrderStatusCardProps) {
+  return <Container>{children}</Container>;
+}
+
+// ============================================================================
+// Header
+// ============================================================================
+
+interface HeaderProps {
+  /** 주문 상태 */
+  status: OrderStatusType;
+  /** 상태 설명 (선택적) */
+  children?: ReactNode;
+}
+
+function Header({ status, children }: HeaderProps) {
+  const statusLabel = STATUS_LABELS[status];
+
+  return (
+    <HeaderContainer>
+      <StatusTitle>{statusLabel}</StatusTitle>
+      {children && <StatusDescription>{children}</StatusDescription>}
+    </HeaderContainer>
+  );
+}
+
+// ============================================================================
+// Accommodation Info (숙박 전용)
+// ============================================================================
+
+interface AccommodationInfoProps {
+  /** 썸네일 이미지 URL */
+  thumbnail: string | null;
+  /** 호텔명 */
+  hotelName: string;
+  /** 객실명 */
+  roomName: string;
+  /** 옵션명 */
+  optionName: string;
+}
+
+function AccommodationInfo({
+  thumbnail,
+  hotelName,
+  roomName,
+  optionName,
+}: AccommodationInfoProps) {
+  return (
+    <ProductInfoContainer>
+      <Thumbnail
+        src={thumbnail || '/default-product.png'}
+        alt={hotelName}
+        loading="lazy"
+      />
+      <ProductDetails>
+        <ProductTitle>{hotelName}</ProductTitle>
+        <ProductSubInfo>
+          <ProductSubText>{roomName}</ProductSubText>
+          <ProductSubTextMuted>{optionName}</ProductSubTextMuted>
+        </ProductSubInfo>
+      </ProductDetails>
+    </ProductInfoContainer>
+  );
+}
+
+// ============================================================================
+// Check Time (숙박 전용)
+// ============================================================================
+
+interface CheckTimeProps {
+  checkIn: {
+    date: string;
+    time: string;
+  };
+  checkOut: {
+    date: string;
+    time: string;
+  };
+}
+
+function CheckTime({ checkIn, checkOut }: CheckTimeProps) {
+  return (
+    <CheckTimeContainer>
+      <CheckTimeColumn>
+        <CheckTimeLabel>체크인</CheckTimeLabel>
+        <CheckTimeValue>
+          <span>{checkIn.date}</span>
+          <span>{checkIn.time}</span>
+        </CheckTimeValue>
+      </CheckTimeColumn>
+      <CheckTimeColumn>
+        <CheckTimeLabel>체크아웃</CheckTimeLabel>
+        <CheckTimeValue>
+          <span>{checkOut.date}</span>
+          <span>{checkOut.time}</span>
+        </CheckTimeValue>
+      </CheckTimeColumn>
+    </CheckTimeContainer>
+  );
+}
+
+// ============================================================================
+// Product List & Item (배송 전용)
+// ============================================================================
+
+interface ProductListProps {
+  children: ReactNode;
+}
+
+function ProductList({ children }: ProductListProps) {
+  return <ProductListContainer>{children}</ProductListContainer>;
+}
+
+interface ProductItemProps {
+  /** 썸네일 이미지 URL */
+  thumbnail: string | null;
+  /** 상품명 */
+  name: string;
+  /** 옵션 (색상, 사이즈 등) */
+  option: string;
+  /** 가격 */
+  price: number;
+  /** 수량 */
+  quantity: number;
+}
+
+function ProductItem({
+  thumbnail,
+  name,
+  option,
+  price,
+  quantity,
+}: ProductItemProps) {
+  return (
+    <ProductInfoContainer>
+      <Thumbnail
+        src={thumbnail || '/default-product.png'}
+        alt={name}
+        loading="lazy"
+      />
+      <ProductDetails>
+        <ProductTitle>{name}</ProductTitle>
+        <ProductSubTextMuted>{option}</ProductSubTextMuted>
+        <ProductPriceRow>
+          <ProductPrice>{formatPriceExact(price)}</ProductPrice>
+          <ProductQuantity>{quantity}개</ProductQuantity>
+        </ProductPriceRow>
+      </ProductDetails>
+    </ProductInfoContainer>
+  );
+}
+
+// ============================================================================
+// Divider
+// ============================================================================
+
+function Divider() {
+  return <DividerLine />;
+}
+
+// ============================================================================
+// Actions & Buttons
+// ============================================================================
+
+interface ActionsProps {
+  children: ReactNode;
+}
+
+function Actions({ children }: ActionsProps) {
+  return <ActionsContainer>{children}</ActionsContainer>;
+}
+
+interface ButtonProps {
+  children: ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+}
+
+function SolidButton({ children, onClick, disabled }: ButtonProps) {
+  return (
+    <SolidButtonStyled onClick={onClick} disabled={disabled}>
+      {children}
+    </SolidButtonStyled>
+  );
+}
+
+function SubtleButton({ children, onClick, disabled }: ButtonProps) {
+  return (
+    <SubtleButtonStyled onClick={onClick} disabled={disabled}>
+      {children}
+    </SubtleButtonStyled>
+  );
+}
+
+// ============================================================================
+// Compound Component Export
+// ============================================================================
+
+export const OrderStatusCard = Object.assign(OrderStatusCardRoot, {
+  Header,
+  AccommodationInfo,
+  CheckTime,
+  ProductList,
+  ProductItem,
+  Divider,
+  Actions,
+  SolidButton,
+  SubtleButton,
+});
+
+// ============================================================================
+// Styled Components
+// ============================================================================
+
+const Container = tw.div`
+  bg-white
+  p-5
+  flex
+  flex-col
+  gap-5
+`;
+
+const HeaderContainer = tw.div`
+  flex
+  flex-col
+  gap-1
+`;
+
+const StatusTitle = tw.h2`
+  text-lg
+  font-bold
+  leading-6
+  text-fg-neutral
+`;
+
+const StatusDescription = tw.p`
+  text-[15px]
+  leading-5
+  text-fg-muted
+`;
+
+const ProductInfoContainer = tw.div`
+  flex
+  gap-3
+  items-start
+`;
+
+const Thumbnail = tw.img`
+  w-[52px]
+  h-[52px]
+  rounded-xl
+  object-cover
+  border
+  border-[rgba(0,0,0,0.05)]
+  flex-shrink-0
+`;
+
+const ProductDetails = tw.div`
+  flex-1
+  flex
+  flex-col
+  gap-1
+`;
+
+const ProductTitle = tw.p`
+  text-[16.5px]
+  font-medium
+  leading-[22px]
+  text-fg-neutral
+`;
+
+const ProductSubInfo = tw.div`
+  flex
+  flex-col
+`;
+
+const ProductSubText = tw.p`
+  text-[15px]
+  leading-5
+  text-fg-neutral
+`;
+
+const ProductSubTextMuted = tw.p`
+  text-[15px]
+  leading-5
+  text-fg-muted
+`;
+
+const ProductPriceRow = tw.div`
+  flex
+  items-center
+  gap-1
+`;
+
+const ProductPrice = tw.span`
+  text-[15px]
+  leading-5
+  text-fg-neutral
+  font-medium
+`;
+
+const ProductQuantity = tw.span`
+  text-[15px]
+  leading-5
+  text-fg-muted
+`;
+
+const CheckTimeContainer = tw.div`
+  flex
+  gap-2
+`;
+
+const CheckTimeColumn = tw.div`
+  flex-1
+  flex
+  flex-col
+  gap-1
+`;
+
+const CheckTimeLabel = tw.p`
+  text-[15px]
+  leading-5
+  text-fg-muted
+`;
+
+const CheckTimeValue = tw.div`
+  flex
+  flex-col
+  text-[16.5px]
+  font-medium
+  leading-[22px]
+  text-fg-neutral
+`;
+
+const ProductListContainer = tw.div`
+  flex
+  flex-col
+  gap-4
+`;
+
+const DividerLine = tw.div`
+  h-px
+  bg-stroke-neutral
+`;
+
+const ActionsContainer = tw.div`
+  flex
+  gap-2
+`;
+
+const SolidButtonStyled = tw.button`
+  flex-1
+  h-11
+  bg-bg-neutral-solid
+  text-fg-on-surface
+  rounded-xl
+  flex
+  items-center
+  justify-center
+  gap-1
+  text-[16.5px]
+  font-medium
+  leading-[22px]
+  hover:opacity-90
+  transition-opacity
+  disabled:opacity-50
+  disabled:cursor-not-allowed
+`;
+
+const SubtleButtonStyled = tw.button`
+  flex-1
+  h-11
+  bg-bg-neutral
+  text-fg-neutral
+  rounded-xl
+  flex
+  items-center
+  justify-center
+  gap-1
+  text-[16.5px]
+  font-medium
+  leading-[22px]
+  hover:opacity-90
+  transition-opacity
+  disabled:opacity-50
+  disabled:cursor-not-allowed
+`;

--- a/apps/shop/src/components/order/PaymentSummarySection.tsx
+++ b/apps/shop/src/components/order/PaymentSummarySection.tsx
@@ -1,0 +1,138 @@
+/**
+ * PaymentSummarySection - 결제 요약 섹션
+ *
+ * 주문의 결제 정보를 요약해서 표시하는 컴포넌트입니다.
+ * 숙박과 배송 타입 모두 지원합니다.
+ *
+ * Usage (숙박):
+ * <PaymentSummarySection
+ *   type="accommodation"
+ *   payment={{
+ *     totalAmount: 13000,
+ *     productAmount: 10000,
+ *     paymentMethod: "카카오페이"
+ *   }}
+ * />
+ *
+ * Usage (배송):
+ * <PaymentSummarySection
+ *   type="shipping"
+ *   payment={{
+ *     totalAmount: 13000,
+ *     productAmount: 10000,
+ *     shippingFee: 3000,
+ *     paymentMethod: "카카오페이"
+ *   }}
+ * />
+ */
+
+import tw from 'tailwind-styled-components';
+
+import { formatPriceExact } from '@/shared';
+
+type OrderType = 'accommodation' | 'shipping';
+
+interface AccommodationPayment {
+  totalAmount: number;
+  productAmount: number;
+  paymentMethod: string;
+}
+
+interface ShippingPayment extends AccommodationPayment {
+  shippingFee: number;
+}
+
+export interface PaymentSummarySectionProps {
+  type: OrderType;
+  payment: AccommodationPayment | ShippingPayment;
+}
+
+export function PaymentSummarySection({
+  payment,
+  type,
+}: PaymentSummarySectionProps) {
+  const isShipping = type === 'shipping';
+  const shippingPayment = payment as ShippingPayment;
+
+  return (
+    <Section>
+      <PaymentHeader>
+        <PaymentTitle>총 결제금액</PaymentTitle>
+        <PaymentTotal>{formatPriceExact(payment.totalAmount)}</PaymentTotal>
+      </PaymentHeader>
+      <PaymentDetails>
+        <PaymentRow>
+          <PaymentLabel>상품금액</PaymentLabel>
+          <PaymentValue>{formatPriceExact(payment.productAmount)}</PaymentValue>
+        </PaymentRow>
+        {isShipping && (
+          <PaymentRow>
+            <PaymentLabel>배송비</PaymentLabel>
+            <PaymentValue>
+              {formatPriceExact(shippingPayment.shippingFee)}
+            </PaymentValue>
+          </PaymentRow>
+        )}
+        <PaymentRow>
+          <PaymentLabel>결제방법</PaymentLabel>
+          <PaymentValue>{payment.paymentMethod}</PaymentValue>
+        </PaymentRow>
+      </PaymentDetails>
+    </Section>
+  );
+}
+
+// ============================================================================
+// Styled Components
+// ============================================================================
+
+const Section = tw.section`
+  bg-white
+  p-5
+  flex
+  flex-col
+  gap-5
+`;
+
+const PaymentHeader = tw.div`
+  flex
+  items-start
+  justify-between
+  gap-3
+`;
+
+const PaymentTitle = tw.h3`
+  text-lg
+  font-bold
+  leading-6
+  text-fg-neutral
+`;
+
+const PaymentTotal = tw.span`
+  text-lg
+  font-bold
+  leading-6
+  text-fg-critical
+`;
+
+const PaymentDetails = tw.div`
+  flex
+  flex-col
+  gap-2
+`;
+
+const PaymentRow = tw.div`
+  flex
+  items-center
+  gap-1
+  text-[15px]
+  leading-5
+  text-fg-muted
+`;
+
+const PaymentLabel = tw.span``;
+
+const PaymentValue = tw.span`
+  flex-1
+  text-right
+`;

--- a/apps/shop/src/components/order/ShippingInfoSection.tsx
+++ b/apps/shop/src/components/order/ShippingInfoSection.tsx
@@ -1,0 +1,109 @@
+/**
+ * ShippingInfoSection - 배송지 정보 섹션
+ *
+ * 배송 주문에서 배송지 정보를 표시하는 컴포넌트입니다.
+ *
+ * Usage:
+ * <ShippingInfoSection
+ *   shipping={{
+ *     recipientName: "김주민",
+ *     phone: "010-0000-0000",
+ *     address: "(12345) 서울 강남구...",
+ *     request: "문 앞에 놓아주세요"
+ *   }}
+ * />
+ */
+
+import tw from 'tailwind-styled-components';
+
+export interface ShippingInfoSectionProps {
+  shipping: {
+    recipientName: string;
+    phone: string;
+    address: string;
+    request?: string;
+  };
+}
+
+export function ShippingInfoSection({ shipping }: ShippingInfoSectionProps) {
+  return (
+    <Section>
+      <SectionHeader>
+        <SectionTitle>배송지</SectionTitle>
+      </SectionHeader>
+      <InfoList>
+        <InfoRow>
+          <InfoLabel>받는사람</InfoLabel>
+          <InfoValue>{shipping.recipientName}</InfoValue>
+        </InfoRow>
+        <InfoRow>
+          <InfoLabel>연락처</InfoLabel>
+          <InfoValue>{shipping.phone}</InfoValue>
+        </InfoRow>
+        <InfoRow>
+          <InfoLabel>주소</InfoLabel>
+          <InfoValueFlex>{shipping.address}</InfoValueFlex>
+        </InfoRow>
+        {shipping.request && (
+          <InfoRow>
+            <InfoLabel>요청사항</InfoLabel>
+            <InfoValueFlex>{shipping.request}</InfoValueFlex>
+          </InfoRow>
+        )}
+      </InfoList>
+    </Section>
+  );
+}
+
+// ============================================================================
+// Styled Components
+// ============================================================================
+
+const Section = tw.section`
+  bg-white
+  p-5
+  flex
+  flex-col
+  gap-5
+`;
+
+const SectionHeader = tw.div`
+  flex
+  items-center
+  justify-between
+`;
+
+const SectionTitle = tw.h3`
+  text-lg
+  font-bold
+  leading-6
+  text-fg-neutral
+`;
+
+const InfoList = tw.div`
+  flex
+  flex-col
+  gap-2
+`;
+
+const InfoRow = tw.div`
+  flex
+  items-start
+  text-[15px]
+  leading-5
+`;
+
+const InfoLabel = tw.span`
+  w-20
+  text-fg-muted
+  flex-shrink-0
+`;
+
+const InfoValue = tw.span`
+  text-fg-neutral
+`;
+
+const InfoValueFlex = tw.span`
+  flex-1
+  text-fg-neutral
+`;

--- a/apps/shop/src/components/order/ShippingOrderStatusCard.tsx
+++ b/apps/shop/src/components/order/ShippingOrderStatusCard.tsx
@@ -1,0 +1,70 @@
+/**
+ * ShippingOrderStatusCard - 배송 주문 상태 카드
+ *
+ * 배송 주문의 상태를 표시하는 컴포넌트입니다.
+ * OrderStatusCard 컴파운드 컴포넌트를 사용합니다.
+ *
+ * Usage:
+ * <ShippingOrderStatusCard
+ *   data={shippingOrderData}
+ *   onTrackDelivery={() => console.log('배송 조회')}
+ *   onReturnRequest={() => console.log('반품 신청')}
+ * />
+ */
+
+import { OrderStatusCard, type OrderStatusType } from './OrderStatusCard';
+
+export interface ShippingProduct {
+  id: string;
+  thumbnail: string | null;
+  name: string;
+  option: string;
+  price: number;
+  quantity: number;
+}
+
+export interface ShippingOrderData {
+  status: OrderStatusType;
+  statusDescription?: string;
+  products: ShippingProduct[];
+}
+
+export interface ShippingOrderStatusCardProps {
+  data: ShippingOrderData;
+  onTrackDelivery: () => void;
+  onReturnRequest: () => void;
+}
+
+export function ShippingOrderStatusCard({
+  data,
+  onTrackDelivery,
+  onReturnRequest,
+}: ShippingOrderStatusCardProps) {
+  return (
+    <OrderStatusCard>
+      <OrderStatusCard.Header status={data.status}>
+        {data.statusDescription}
+      </OrderStatusCard.Header>
+      <OrderStatusCard.ProductList>
+        {data.products.map(product => (
+          <OrderStatusCard.ProductItem
+            key={product.id}
+            thumbnail={product.thumbnail}
+            name={product.name}
+            option={product.option}
+            price={product.price}
+            quantity={product.quantity}
+          />
+        ))}
+      </OrderStatusCard.ProductList>
+      <OrderStatusCard.Actions>
+        <OrderStatusCard.SolidButton onClick={onTrackDelivery}>
+          배송조회
+        </OrderStatusCard.SolidButton>
+        <OrderStatusCard.SubtleButton onClick={onReturnRequest}>
+          반품 신청
+        </OrderStatusCard.SubtleButton>
+      </OrderStatusCard.Actions>
+    </OrderStatusCard>
+  );
+}

--- a/apps/shop/src/components/order/UserInfoSection.tsx
+++ b/apps/shop/src/components/order/UserInfoSection.tsx
@@ -1,0 +1,87 @@
+/**
+ * UserInfoSection - 이용자 정보 섹션
+ *
+ * 숙박 주문에서 이용자 정보를 표시하는 컴포넌트입니다.
+ *
+ * Usage:
+ * <UserInfoSection
+ *   user={{ name: "김주민", phone: "010-0000-0000" }}
+ * />
+ */
+
+import tw from 'tailwind-styled-components';
+
+export interface UserInfoSectionProps {
+  user: {
+    name: string;
+    phone: string;
+  };
+}
+
+export function UserInfoSection({ user }: UserInfoSectionProps) {
+  return (
+    <Section>
+      <SectionHeader>
+        <SectionTitle>이용자</SectionTitle>
+      </SectionHeader>
+      <InfoList>
+        <InfoRow>
+          <InfoLabel>이름</InfoLabel>
+          <InfoValue>{user.name}</InfoValue>
+        </InfoRow>
+        <InfoRow>
+          <InfoLabel>연락처</InfoLabel>
+          <InfoValue>{user.phone}</InfoValue>
+        </InfoRow>
+      </InfoList>
+    </Section>
+  );
+}
+
+// ============================================================================
+// Styled Components
+// ============================================================================
+
+const Section = tw.section`
+  bg-white
+  p-5
+  flex
+  flex-col
+  gap-5
+`;
+
+const SectionHeader = tw.div`
+  flex
+  items-center
+  justify-between
+`;
+
+const SectionTitle = tw.h3`
+  text-lg
+  font-bold
+  leading-6
+  text-fg-neutral
+`;
+
+const InfoList = tw.div`
+  flex
+  flex-col
+  gap-2
+`;
+
+const InfoRow = tw.div`
+  flex
+  items-start
+  text-[15px]
+  leading-5
+`;
+
+const InfoLabel = tw.span`
+  w-20
+  text-fg-muted
+  flex-shrink-0
+`;
+
+const InfoValue = tw.span`
+  text-fg-neutral
+`;

--- a/apps/shop/src/components/order/index.ts
+++ b/apps/shop/src/components/order/index.ts
@@ -1,0 +1,7 @@
+export * from './OrderStatusCard';
+export * from './AccommodationOrderStatusCard';
+export * from './ShippingOrderStatusCard';
+export * from './CancelledProductsSection';
+export * from './UserInfoSection';
+export * from './ShippingInfoSection';
+export * from './PaymentSummarySection';

--- a/apps/shop/src/routes/__root.tsx
+++ b/apps/shop/src/routes/__root.tsx
@@ -1,6 +1,6 @@
 import { createRootRoute, Outlet } from '@tanstack/react-router';
 import { TanStackRouterDevtools } from '@tanstack/router-devtools';
-import React from 'react';
+import { Toaster } from 'sonner';
 
 export const Route = createRootRoute({
   component: () => (
@@ -8,6 +8,7 @@ export const Route = createRootRoute({
       <div className="min-h-screen bg-gray-50">
         <Outlet />
       </div>
+      <Toaster position="top-center" richColors />
       <TanStackRouterDevtools />
     </>
   ),

--- a/apps/shop/src/routes/order.$orderId.tsx
+++ b/apps/shop/src/routes/order.$orderId.tsx
@@ -1,0 +1,375 @@
+/**
+ * OrderDetailPage - 주문 상세 페이지
+ *
+ * 주문 상세 정보를 표시하는 페이지입니다.
+ * 숙박(accommodation)과 배송(shipping) 두 가지 타입을 지원합니다.
+ * 주문 타입은 API 응답의 type 필드로 결정됩니다.
+ *
+ * Usage:
+ * - /order/acc-123 (숙박 주문)
+ * - /order/ship-456 (배송 주문)
+ */
+
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { X } from 'lucide-react';
+import { toast } from 'sonner';
+import tw from 'tailwind-styled-components';
+
+import {
+  ORDER_STATUS,
+  AccommodationOrderStatusCard,
+  ShippingOrderStatusCard,
+  CancelledProductsSection,
+  UserInfoSection,
+  ShippingInfoSection,
+  PaymentSummarySection,
+} from '@/components/order';
+
+// ============================================================================
+// Route Definition
+// ============================================================================
+
+export const Route = createFileRoute('/order/$orderId')({
+  component: OrderDetailPage,
+});
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface AccommodationOrderData {
+  type: 'accommodation';
+  orderId: string;
+  orderDate: string;
+  orderNumber: string;
+  status: (typeof ORDER_STATUS)[keyof typeof ORDER_STATUS];
+  statusDescription?: string;
+  accommodation: {
+    thumbnail: string | null;
+    hotelName: string;
+    roomName: string;
+    optionName: string;
+  };
+  checkIn: {
+    date: string;
+    time: string;
+  };
+  checkOut: {
+    date: string;
+    time: string;
+  };
+  user: {
+    name: string;
+    phone: string;
+  };
+  payment: {
+    totalAmount: number;
+    productAmount: number;
+    paymentMethod: string;
+  };
+}
+
+interface ShippingOrderData {
+  type: 'shipping';
+  orderId: string;
+  orderDate: string;
+  orderNumber: string;
+  status: (typeof ORDER_STATUS)[keyof typeof ORDER_STATUS];
+  statusDescription?: string;
+  products: Array<{
+    id: string;
+    thumbnail: string | null;
+    name: string;
+    option: string;
+    price: number;
+    quantity: number;
+  }>;
+  cancelledProducts?: Array<{
+    id: string;
+    thumbnail: string | null;
+    name: string;
+    option: string;
+    price: number;
+    quantity: number;
+  }>;
+  shipping: {
+    recipientName: string;
+    phone: string;
+    address: string;
+    request?: string;
+  };
+  payment: {
+    totalAmount: number;
+    productAmount: number;
+    shippingFee: number;
+    paymentMethod: string;
+  };
+}
+
+type OrderData = AccommodationOrderData | ShippingOrderData;
+
+// ============================================================================
+// Mock Data
+// ============================================================================
+
+const MOCK_ACCOMMODATION_ORDER: AccommodationOrderData = {
+  type: 'accommodation',
+  orderId: '123456',
+  orderDate: '25.01.01 13:00',
+  orderNumber: '123456',
+  status: ORDER_STATUS.RESERVATION_CONFIRMED,
+  accommodation: {
+    thumbnail:
+      'https://images.unsplash.com/photo-1566073771259-6a8506099945?w=200&h=200&fit=crop',
+    hotelName: '인천 월미도 고요하우스',
+    roomName: '로얄 트윈',
+    optionName: '3인 패키지',
+  },
+  checkIn: {
+    date: '25.12.10(금)',
+    time: '17:00',
+  },
+  checkOut: {
+    date: '25.12.14(금)',
+    time: '13:00',
+  },
+  user: {
+    name: '김주민',
+    phone: '010-0000-0000',
+  },
+  payment: {
+    totalAmount: 13000,
+    productAmount: 10000,
+    paymentMethod: '카카오페이',
+  },
+};
+
+const MOCK_SHIPPING_ORDER: ShippingOrderData = {
+  type: 'shipping',
+  orderId: '789012',
+  orderDate: '25.01.01 13:00',
+  orderNumber: '789012',
+  status: ORDER_STATUS.SHIPPING,
+  products: [
+    {
+      id: '1',
+      thumbnail:
+        'https://images.unsplash.com/photo-1434389677669-e08b4cac3105?w=200&h=200&fit=crop',
+      name: '우먼즈 짐 액티브 롱 슬리브 (3color)',
+      option: '라지 / 미디움',
+      price: 17500,
+      quantity: 1,
+    },
+    {
+      id: '2',
+      thumbnail:
+        'https://images.unsplash.com/photo-1434389677669-e08b4cac3105?w=200&h=200&fit=crop',
+      name: '우먼즈 짐 액티브 우먼즈 짐 액티브 롱 슬리브 (3color)',
+      option: '',
+      price: 17500,
+      quantity: 1,
+    },
+  ],
+  cancelledProducts: [
+    {
+      id: '3',
+      thumbnail:
+        'https://images.unsplash.com/photo-1434389677669-e08b4cac3105?w=200&h=200&fit=crop',
+      name: '우먼즈 짐 액티브 롱 슬리브 (3color)',
+      option: '라지 / 미디움',
+      price: 17500,
+      quantity: 1,
+    },
+    {
+      id: '4',
+      thumbnail:
+        'https://images.unsplash.com/photo-1434389677669-e08b4cac3105?w=200&h=200&fit=crop',
+      name: '우먼즈 짐 액티브 우먼즈 짐 액티브 롱 슬리브 (3color)',
+      option: '',
+      price: 17500,
+      quantity: 1,
+    },
+  ],
+  shipping: {
+    recipientName: '김주민',
+    phone: '010-0000-0000',
+    address: '(12345) 서울 강남구 강남대로 123 강남아파트 102동 101호',
+    request: '가나다라',
+  },
+  payment: {
+    totalAmount: 13000,
+    productAmount: 10000,
+    shippingFee: 3000,
+    paymentMethod: '카카오페이',
+  },
+};
+
+// ============================================================================
+// Mock API
+// ============================================================================
+
+/**
+ * 주문 상세 조회 Mock API
+ * orderId에 'ship'이 포함되면 배송 주문, 그 외에는 숙박 주문 반환
+ * TODO: 실제 API 연동 시 교체 필요
+ */
+function fetchOrderDetail(orderId: string): OrderData {
+  if (orderId.includes('ship')) {
+    return { ...MOCK_SHIPPING_ORDER, orderId, orderNumber: orderId };
+  }
+  return { ...MOCK_ACCOMMODATION_ORDER, orderId, orderNumber: orderId };
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+function OrderDetailPage() {
+  const { orderId } = Route.useParams();
+  const navigate = useNavigate();
+
+  // API에서 주문 데이터 조회 (현재는 Mock)
+  const orderData = fetchOrderDetail(orderId);
+
+  const handleClose = () => {
+    navigate({ to: '/' });
+  };
+
+  const handleCancelRequest = () => {
+    toast.success('취소 신청이 완료되었습니다.');
+  };
+
+  const handleTrackDelivery = () => {
+    toast.info('배송 조회 페이지로 이동합니다.');
+  };
+
+  const handleReturnRequest = () => {
+    toast.success('반품 신청이 완료되었습니다.');
+  };
+
+  const handleCancelWithdraw = () => {
+    toast.success('취소 철회가 완료되었습니다.');
+  };
+
+  return (
+    <Container>
+      {/* Header */}
+      <Header>
+        <CloseButton onClick={handleClose}>
+          <X size={24} />
+        </CloseButton>
+      </Header>
+
+      {/* Content */}
+      <ContentWrapper>
+        {/* Order Info */}
+        <Section>
+          <OrderInfoContainer>
+            <OrderDate>{orderData.orderDate}</OrderDate>
+            <OrderNumber>주문번호: {orderData.orderNumber}</OrderNumber>
+          </OrderInfoContainer>
+        </Section>
+
+        {/* Order Status Card */}
+        {orderData.type === 'accommodation' ? (
+          <AccommodationOrderStatusCard
+            data={orderData}
+            onCancelRequest={handleCancelRequest}
+          />
+        ) : (
+          <ShippingOrderStatusCard
+            data={orderData}
+            onTrackDelivery={handleTrackDelivery}
+            onReturnRequest={handleReturnRequest}
+          />
+        )}
+
+        {/* Cancelled Products Section (배송 only) */}
+        {orderData.type === 'shipping' && (
+          <CancelledProductsSection
+            products={orderData.cancelledProducts}
+            onWithdraw={handleCancelWithdraw}
+          />
+        )}
+
+        {/* User Info (숙박) or Shipping Info (배송) */}
+        {orderData.type === 'accommodation' ? (
+          <UserInfoSection user={orderData.user} />
+        ) : (
+          <ShippingInfoSection shipping={orderData.shipping} />
+        )}
+
+        {/* Payment Summary */}
+        <PaymentSummarySection
+          payment={orderData.payment}
+          type={orderData.type}
+        />
+      </ContentWrapper>
+    </Container>
+  );
+}
+
+// ============================================================================
+// Styled Components
+// ============================================================================
+
+const Container = tw.div`
+  min-h-screen
+  bg-bg-layer
+  max-w-[600px]
+  mx-auto
+`;
+
+const Header = tw.header`
+  w-full
+  h-16
+  px-5
+  py-5
+  bg-white
+  flex
+  items-center
+  gap-5
+`;
+
+const CloseButton = tw.button`
+  w-6
+  h-6
+  flex
+  items-center
+  justify-center
+  text-fg-neutral
+`;
+
+const ContentWrapper = tw.div`
+  bg-bg-layer-base
+  flex
+  flex-col
+  gap-2
+`;
+
+const Section = tw.section`
+  bg-white
+  p-5
+  flex
+  flex-col
+  gap-5
+`;
+
+const OrderInfoContainer = tw.div`
+  flex
+  flex-col
+  gap-1
+`;
+
+const OrderDate = tw.p`
+  text-[21px]
+  font-bold
+  leading-7
+  text-fg-neutral
+`;
+
+const OrderNumber = tw.p`
+  text-[13.5px]
+  leading-[18px]
+  text-fg-muted
+`;


### PR DESCRIPTION

<img width="667" height="833" alt="image" src="https://github.com/user-attachments/assets/f30121a0-c082-4da7-aa0e-f48b44c36159" />

<img width="732" height="931" alt="image" src="https://github.com/user-attachments/assets/6e1aebb7-8510-47cb-b9aa-408b3099a258" />



## Summary
- OrderStatusCard 컴파운드 컴포넌트 패턴으로 구현 (숙박/배송 주문 타입 지원)
- 주문 상세 페이지 (`/order/$orderId`) 구현
- 컴포넌트 모듈화 및 분리

## 주요 변경사항

### OrderStatusCard 컴파운드 컴포넌트
- `OrderStatusCard.Header` - 주문 상태 헤더
- `OrderStatusCard.AccommodationInfo` - 숙박 정보
- `OrderStatusCard.CheckTime` - 체크인/체크아웃 시간
- `OrderStatusCard.ProductList` / `ProductItem` - 상품 목록
- `OrderStatusCard.Actions` / `SolidButton` / `SubtleButton` - 액션 버튼

### 주문 상세 페이지
- 숙박 주문: 예약 정보, 체크인/아웃, 이용자 정보, 결제 요약
- 배송 주문: 상품 목록, 배송지 정보, 취소요청 섹션, 결제 요약

### 분리된 컴포넌트
- `AccommodationOrderStatusCard` - 숙박 주문 상태 카드
- `ShippingOrderStatusCard` - 배송 주문 상태 카드
- `UserInfoSection` - 이용자 정보
- `ShippingInfoSection` - 배송지 정보
- `PaymentSummarySection` - 결제 요약
- `CancelledProductsSection` - 취소 요청 상품

## Test plan
- [ ] `/order/123` 접속 시 숙박 주문 상세 페이지 표시 확인
- [ ] `/order/ship-456` 접속 시 배송 주문 상세 페이지 표시 확인
- [ ] 각 버튼 클릭 시 토스트 메시지 표시 확인

🤖 Generated with [Claude Code](https://claude.ai/code)