### PR TITLE
FEAT: PortOne 결제 SDK 연동 및 결제 처리 구현

### DIFF
--- a/apps/shop/src/components/new-order/PaymentMethodSection.tsx
+++ b/apps/shop/src/components/new-order/PaymentMethodSection.tsx
@@ -11,39 +11,50 @@ import tw from 'tailwind-styled-components';
 import type { NewOrderFormData } from '@/routes/new-order.$orderNumber';
 
 export type PaymentType = 'simple' | 'general';
-export type PaymentMethod = 'kakaopay' | 'naverpay' | 'toss' | 'card' | 'bank';
+export type PaymentMethod =
+  | 'kakaopay'
+  | 'naverpay'
+  | 'toss'
+  | 'card'
+  | 'vbank'
+  | 'bank';
 
-const SIMPLE_PAYMENT_METHODS = [
-  { value: 'kakaopay' as const, label: '카카오페이' },
-  { value: 'naverpay' as const, label: '네이버페이' },
-  { value: 'toss' as const, label: '토스' },
-];
+// TODO: 간편결제 추후 활성화
+// const SIMPLE_PAYMENT_METHODS = [
+//   { value: 'kakaopay' as const, label: '카카오페이' },
+//   { value: 'naverpay' as const, label: '네이버페이' },
+//   { value: 'toss' as const, label: '토스' },
+// ];
 
 const GENERAL_PAYMENT_METHODS = [
   { value: 'card' as const, label: '신용/체크카드' },
-  { value: 'bank' as const, label: '계좌이체' },
+  { value: 'vbank' as const, label: '가상계좌' },
+  // TODO: 계좌이체 추후 활성화
+  // { value: 'bank' as const, label: '계좌이체' },
 ];
 
 export function PaymentMethodSection() {
   const { watch, setValue } = useFormContext<NewOrderFormData>();
 
-  const paymentType = watch('paymentType');
+  // TODO: 간편결제 추후 활성화
+  // const paymentType = watch('paymentType');
   const paymentMethod = watch('paymentMethod');
 
-  const handlePaymentTypeChange = (type: PaymentType) => {
-    setValue('paymentType', type);
-    // 결제 타입 변경 시 기본 결제수단으로 초기화
-    setValue('paymentMethod', type === 'simple' ? 'kakaopay' : 'card');
-  };
+  // TODO: 간편결제 추후 활성화
+  // const handlePaymentTypeChange = (type: PaymentType) => {
+  //   setValue('paymentType', type);
+  //   // 결제 타입 변경 시 기본 결제수단으로 초기화
+  //   setValue('paymentMethod', type === 'simple' ? 'kakaopay' : 'card');
+  // };
 
-  const methods =
-    paymentType === 'simple' ? SIMPLE_PAYMENT_METHODS : GENERAL_PAYMENT_METHODS;
+  const methods = GENERAL_PAYMENT_METHODS;
 
   return (
     <Section>
       <SectionTitle>결제수단</SectionTitle>
 
-      <TabContainer>
+      {/* TODO: 간편결제 탭 추후 활성화 */}
+      {/* <TabContainer>
         <Tab
           $selected={paymentType === 'simple'}
           onClick={() => handlePaymentTypeChange('simple')}
@@ -56,7 +67,7 @@ export function PaymentMethodSection() {
         >
           일반결제
         </Tab>
-      </TabContainer>
+      </TabContainer> */}
 
       <MethodList>
         {methods.map(method => (

--- a/apps/shop/src/routes/new-order.$orderNumber.tsx
+++ b/apps/shop/src/routes/new-order.$orderNumber.tsx
@@ -9,6 +9,7 @@ import type { PaymentRequest } from '@portone/browser-sdk/v2';
 import * as PortOne from '@portone/browser-sdk/v2';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import axios from 'axios';
+import dayjs from 'dayjs';
 import { ArrowLeft } from 'lucide-react';
 import { Suspense, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -59,13 +60,43 @@ function NewOrderContent({ orderNumber }: { orderNumber: string }) {
       userName: '',
       userPhone: '',
       useSameAsMe: false,
-      paymentType: 'simple',
-      paymentMethod: 'kakaopay',
+      paymentType: 'general',
+      paymentMethod: 'card',
     },
   });
 
   const handleBack = () => {
     navigate({ to: '/' });
+  };
+
+  const getPortOnePayMethod = (
+    method: PaymentMethod
+  ): Pick<PaymentRequest, 'payMethod' | 'easyPay' | 'virtualAccount'> => {
+    switch (method) {
+      // TODO: 간편결제 추후 활성화
+      // case 'kakaopay':
+      //   return { payMethod: 'EASY_PAY', easyPay: { provider: 'KAKAOPAY' } };
+      // case 'naverpay':
+      //   return { payMethod: 'EASY_PAY', easyPay: { provider: 'NAVERPAY' } };
+      // case 'toss':
+      //   return { payMethod: 'EASY_PAY', easyPay: { provider: 'TOSSPAY' } };
+      case 'card':
+        return { payMethod: 'CARD' };
+      case 'vbank':
+        return {
+          payMethod: 'VIRTUAL_ACCOUNT',
+          virtualAccount: {
+            accountExpiry: {
+              dueDate: dayjs().add(1, 'day').endOf('day').toISOString(),
+            },
+          },
+        };
+      // TODO: 계좌이체 추후 활성화
+      // case 'bank':
+      //   return { payMethod: 'TRANSFER' };
+      default:
+        return { payMethod: 'CARD' };
+    }
   };
 
   const paymentComplete = async (paymentResult: unknown) => {
@@ -89,23 +120,26 @@ function NewOrderContent({ orderNumber }: { orderNumber: string }) {
     setIsSubmitting(true);
 
     try {
-      const paymentMethod: PaymentRequest = {
+      const payMethodConfig = getPortOnePayMethod(formData.paymentMethod);
+
+      const paymentRequest: PaymentRequest = {
         storeId: 'store-225e8f7c-301b-421e-bd54-189066bbb97e',
         channelKey: 'channel-key-be836e0a-6537-4a86-bf9d-f99211e0be6c',
         paymentId: orderNumber,
         orderName: `YesTravel - ${data.product.name}`,
         totalAmount: data.totalAmount,
         currency: 'KRW',
-        payMethod: 'CARD',
+        ...payMethodConfig,
         customer: {
           customerId: orderNumber,
           fullName: formData.userName,
+          email: 'info@yestravel.co.kr',
           phoneNumber: formData.userPhone.replace(/-/g, ''),
         },
         redirectUrl: `${API_BASEURL}/payment/complete-redirect?origin=${window.location.origin}`,
       };
 
-      const response = await PortOne.requestPayment(paymentMethod);
+      const response = await PortOne.requestPayment(paymentRequest);
 
       if (!response || response.code === 'FAILURE_TYPE_PG') {
         toast.error('결제가 실패했습니다.');


### PR DESCRIPTION
## Summary

- **PortOne 결제 SDK 연동**: 주문서 작성 페이지에서 실제 결제 처리 구현
- **결제 수단 지원**: 신용/체크카드, 가상계좌 결제 지원
- **결제 완료 플로우**: 결제 성공 시 주문 상세 페이지로 이동

## 주요 변경사항

### Frontend - Shop

**결제 처리 플로우:**
1. 예약자 정보 입력 (이름, 전화번호)
2. 결제 수단 선택 (카드/가상계좌)
3. PortOne SDK를 통한 결제 요청
4. 결제 완료 후 `shopPayment.complete` API 호출
5. 주문 상세 페이지로 이동

**결제 수단별 PortOne 설정:**
```typescript
// 카드 결제
{ payMethod: 'CARD' }

// 가상계좌 (1일 후 만료)
{ 
  payMethod: 'VIRTUAL_ACCOUNT',
  virtualAccount: {
    accountExpiry: { dueDate: '...' }
  }
}
```

**임시 비활성화 항목 (TODO):**
- 간편결제 탭 (카카오페이, 네이버페이, 토스)
- 계좌이체 결제

## 영향 범위

### 관련 파일
- `apps/shop/src/routes/new-order.$orderNumber.tsx` - 결제 처리 로직
- `apps/shop/src/components/new-order/PaymentMethodSection.tsx` - 결제 수단 선택 UI

### Breaking Changes
- 없음 (신규 기능)

🤖 Generated with [Claude Code](https://claude.com/claude-code)