### PR TITLE
FEAT: Shop 카카오 로그인 프론트엔드 구현

### DIFF
--- a/apps/shop/src/components/auth/LoginBottomSheet.tsx
+++ b/apps/shop/src/components/auth/LoginBottomSheet.tsx
@@ -13,12 +13,24 @@
 
 import { useState } from 'react';
 import SnappyModal, { useCurrentModal } from 'react-snappy-modal';
+import { toast } from 'sonner';
 import tw from 'tailwind-styled-components';
 
 import { LoginStep } from './LoginStep';
 import { OTPStep } from './OTPStep';
 
 import { useKeyboardHeight } from '@/hooks/useKeyboardHeight';
+import {
+  EMPTY_OTP_CODE,
+  isValidPhoneNumber,
+  OTP_COUNTDOWN_SECONDS,
+  OTP_LENGTH,
+  codeToArray,
+  redirectToSocialLogin,
+  saveTokens,
+  type SocialProvider,
+} from '@/shared/auth';
+import { trpc } from '@/shared/trpc/trpc';
 
 export interface LoginResult {
   success: boolean;
@@ -33,66 +45,107 @@ function LoginBottomSheet() {
 
   const [step, setStep] = useState<Step>('login');
   const [phoneNumber, setPhoneNumber] = useState('');
-  const [otpCode, setOtpCode] = useState(['', '', '', '', '', '']);
-  const [isLoading, setIsLoading] = useState(false);
+  const [otpCode, setOtpCode] = useState<string[]>(EMPTY_OTP_CODE);
   const [error, setError] = useState<string | null>(null);
-  const [countdown, setCountdown] = useState(180);
+  const [countdown, setCountdown] = useState(OTP_COUNTDOWN_SECONDS);
 
-  const isValidPhoneNumber = /^01[0-9]{8,9}$/.test(phoneNumber);
+  const isPhoneValid = isValidPhoneNumber(phoneNumber);
+
+  // SMS 인증번호 요청
+  const requestVerificationMutation =
+    trpc.shopAuth.requestVerification.useMutation();
+
+  // SMS 인증번호 확인 및 로그인
+  const verifyCodeMutation = trpc.shopAuth.verifyCode.useMutation({
+    onSuccess: data => {
+      saveTokens(data);
+      toast.success('로그인 성공!');
+      resolveModal({ success: true, isNewMember: false });
+    },
+  });
 
   const handleClose = () => {
     resolveModal(null);
   };
 
-  const handleRequestOTP = () => {
-    if (!isValidPhoneNumber) {
+  const handleRequestOTP = async () => {
+    if (!isPhoneValid) {
       setError('올바른 전화번호 형식이 아닙니다');
       return;
     }
 
     setError(null);
-    setIsLoading(true);
 
-    // TODO: API 연동 - shopAuth.requestVerification
-    setTimeout(() => {
-      setIsLoading(false);
-      setCountdown(180);
+    try {
+      const result = await requestVerificationMutation.mutateAsync({
+        phone: phoneNumber,
+      });
+
+      setCountdown(OTP_COUNTDOWN_SECONDS);
       setStep('otp');
-    }, 500);
+
+      // 개발환경에서 인증번호 자동 입력
+      if (result.code) {
+        setOtpCode(codeToArray(result.code));
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : '인증번호 발송에 실패했습니다'
+      );
+    }
   };
 
-  const handleVerifyOTP = () => {
+  const handleVerifyOTP = async () => {
     const code = otpCode.join('');
-    if (code.length !== 6) {
-      setError('인증번호 6자리를 입력해주세요');
+    if (code.length !== OTP_LENGTH) {
+      setError(`인증번호 ${OTP_LENGTH}자리를 입력해주세요`);
       return;
     }
 
     setError(null);
-    setIsLoading(true);
 
-    // TODO: API 연동 - shopAuth.verifyCode
-    setTimeout(() => {
-      setIsLoading(false);
-      resolveModal({ success: true, isNewMember: false });
-    }, 500);
+    try {
+      await verifyCodeMutation.mutateAsync({
+        phone: phoneNumber,
+        code,
+      });
+      // 성공 시 onSuccess에서 처리됨
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '인증에 실패했습니다');
+    }
   };
 
-  const handleResendOTP = () => {
-    setOtpCode(['', '', '', '', '', '']);
-    setCountdown(180);
+  const handleResendOTP = async () => {
+    setOtpCode(EMPTY_OTP_CODE);
     setError(null);
-    // TODO: API 연동 - shopAuth.requestVerification
+
+    try {
+      const result = await requestVerificationMutation.mutateAsync({
+        phone: phoneNumber,
+      });
+
+      setCountdown(OTP_COUNTDOWN_SECONDS);
+
+      // 개발환경에서 인증번호 자동 입력
+      if (result.code) {
+        setOtpCode(codeToArray(result.code));
+      }
+
+      toast.success('인증번호가 재발송되었습니다');
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : '인증번호 발송에 실패했습니다'
+      );
+    }
   };
 
-  const handleSocialLogin = (provider: 'kakao' | 'naver') => {
-    // TODO: OAuth 연동
-    console.log(`${provider} 로그인 시작`);
+  const handleSocialLogin = (provider: SocialProvider) => {
+    redirectToSocialLogin(provider);
   };
 
   const handleBack = () => {
     setStep('login');
-    setOtpCode(['', '', '', '', '', '']);
+    setOtpCode(EMPTY_OTP_CODE);
     setError(null);
   };
 
@@ -112,7 +165,7 @@ function LoginBottomSheet() {
             onPhoneNumberChange={setPhoneNumber}
             onRequestOTP={handleRequestOTP}
             onSocialLogin={handleSocialLogin}
-            isLoading={isLoading}
+            isLoading={requestVerificationMutation.isPending}
             error={error}
             onErrorClear={handleErrorClear}
           />
@@ -126,8 +179,10 @@ function LoginBottomSheet() {
             onVerify={handleVerifyOTP}
             onResend={handleResendOTP}
             onBack={handleBack}
+            onClose={handleClose}
             countdown={countdown}
-            isLoading={isLoading}
+            isLoading={verifyCodeMutation.isPending}
+            isResending={requestVerificationMutation.isPending}
             error={error}
           />
         )}
@@ -160,8 +215,6 @@ const Overlay = tw.div`
 const BottomSheetContainer = tw.div`
   w-full
   max-w-[600px]
-  bg-bg-layer
-  rounded-t-[32px]
   flex
   flex-col
   overflow-hidden

--- a/apps/shop/src/components/auth/LoginStep.tsx
+++ b/apps/shop/src/components/auth/LoginStep.tsx
@@ -17,12 +17,13 @@
 import tw from 'tailwind-styled-components';
 
 import { Button } from '@/components/common';
+import { isValidPhoneNumber, type SocialProvider } from '@/shared/auth';
 
 export interface LoginStepProps {
   phoneNumber: string;
   onPhoneNumberChange: (value: string) => void;
   onRequestOTP: () => void;
-  onSocialLogin: (provider: 'kakao' | 'naver') => void;
+  onSocialLogin: (provider: SocialProvider) => void;
   isLoading: boolean;
   error: string | null;
   onErrorClear: () => void;
@@ -37,7 +38,7 @@ export function LoginStep({
   error,
   onErrorClear,
 }: LoginStepProps) {
-  const isValidPhoneNumber = /^01[0-9]{8,9}$/.test(phoneNumber);
+  const isPhoneValid = isValidPhoneNumber(phoneNumber);
 
   const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onPhoneNumberChange(e.target.value.replace(/\D/g, ''));
@@ -46,9 +47,6 @@ export function LoginStep({
 
   return (
     <StepContent>
-      {/* 상단 라운드 여백 */}
-      <TopSpacer />
-
       {/* 로그인 타이틀 */}
       <Title>로그인</Title>
 
@@ -66,10 +64,7 @@ export function LoginStep({
         {error && <ErrorMessage>{error}</ErrorMessage>}
       </Section>
 
-      <Button
-        onClick={onRequestOTP}
-        disabled={!isValidPhoneNumber || isLoading}
-      >
+      <Button onClick={onRequestOTP} disabled={!isPhoneValid || isLoading}>
         {isLoading ? '발송 중...' : '연락처 인증'}
       </Button>
 
@@ -122,16 +117,12 @@ function NaverIcon() {
 
 // Styled Components
 const StepContent = tw.div`
-  px-5
-  pb-5
+  p-5
   bg-white
   flex
   flex-col
   gap-5
-`;
-
-const TopSpacer = tw.div`
-  h-3
+  rounded-t-[32px]
 `;
 
 const Title = tw.h2`

--- a/apps/shop/src/components/auth/OTPStep.tsx
+++ b/apps/shop/src/components/auth/OTPStep.tsx
@@ -8,26 +8,31 @@
  *   otpCode={otpCode}
  *   onOtpChange={handleOtpChange}
  *   onVerify={handleVerifyOTP}
+ *   onResend={handleResendOTP}
+ *   onClose={handleClose}
  *   countdown={countdown}
  *   isLoading={isLoading}
  *   error={error}
  * />
  */
 
+import { X } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import tw from 'tailwind-styled-components';
 
 import { Button } from '@/components/common';
 
 export interface OTPStepProps {
-  phoneNumber: string;
+  phoneNumber?: string;
   otpCode: string[];
   onOtpChange: (newOtp: string[]) => void;
   onVerify: () => void;
   onResend: () => void;
-  onBack: () => void;
+  onBack?: () => void;
+  onClose?: () => void;
   countdown: number;
   isLoading: boolean;
+  isResending?: boolean;
   error: string | null;
 }
 
@@ -35,8 +40,11 @@ export function OTPStep({
   otpCode,
   onOtpChange,
   onVerify,
+  onResend,
+  onClose,
   countdown,
   isLoading,
+  isResending = false,
   error,
 }: OTPStepProps) {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -63,31 +71,49 @@ export function OTPStep({
 
   return (
     <StepContent>
-      {/* 상단 라운드 여백 */}
-      <TopSpacer />
-
-      {/* 타이틀 */}
-      <Title>인증번호를 입력해 주세요.</Title>
+      {/* 타이틀 + 닫기 버튼 */}
+      <TitleRow>
+        <Title>인증번호를 입력해 주세요.</Title>
+        {onClose && (
+          <CloseButton onClick={onClose}>
+            <X size={24} />
+          </CloseButton>
+        )}
+      </TitleRow>
 
       {/* 인증번호 입력 섹션 */}
       <Section>
         <SectionLabel>인증번호</SectionLabel>
-        <InputWrapper>
-          <OTPInput
-            ref={inputRef}
-            type="tel"
-            inputMode="numeric"
-            placeholder="숫자만 입력해 주세요."
-            value={otpValue}
-            onChange={handleInputChange}
-            maxLength={6}
-          />
-          <TimerText>{formatCountdown(countdown)}</TimerText>
-        </InputWrapper>
+        <InputRow>
+          <InputWrapper>
+            <OTPInput
+              ref={inputRef}
+              type="tel"
+              inputMode="numeric"
+              placeholder="숫자만 입력해 주세요."
+              value={otpValue}
+              onChange={handleInputChange}
+              maxLength={6}
+            />
+            <TimerText>{formatCountdown(countdown)}</TimerText>
+          </InputWrapper>
+          <ResendButton
+            variant="outline"
+            size="medium"
+            onClick={onResend}
+            disabled={isResending}
+          >
+            재전송
+          </ResendButton>
+        </InputRow>
         {error && <ErrorMessage>{error}</ErrorMessage>}
       </Section>
 
-      <Button onClick={onVerify} disabled={otpValue.length !== 6 || isLoading}>
+      <Button
+        size="xlarge"
+        onClick={onVerify}
+        disabled={otpValue.length !== 6 || isLoading}
+      >
         {isLoading ? '확인 중...' : '확인'}
       </Button>
     </StepContent>
@@ -96,16 +122,19 @@ export function OTPStep({
 
 // Styled Components
 const StepContent = tw.div`
-  px-5
-  pb-5
+  p-5
   bg-white
   flex
   flex-col
   gap-5
+  rounded-t-[32px]
 `;
 
-const TopSpacer = tw.div`
-  h-3
+const TitleRow = tw.div`
+  flex
+  items-center
+  justify-between
+  gap-2
 `;
 
 const Title = tw.h2`
@@ -113,6 +142,19 @@ const Title = tw.h2`
   text-[21px]
   font-bold
   leading-7
+  flex-1
+`;
+
+const CloseButton = tw.button`
+  w-11
+  h-11
+  flex
+  items-center
+  justify-center
+  bg-bg-neutral
+  rounded-full
+  text-fg-neutral
+  shrink-0
 `;
 
 const Section = tw.div`
@@ -128,7 +170,14 @@ const SectionLabel = tw.p`
   leading-5
 `;
 
+const InputRow = tw.div`
+  flex
+  items-center
+  gap-2
+`;
+
 const InputWrapper = tw.div`
+  flex-1
   h-[44px]
   px-3
   bg-bg-field
@@ -157,6 +206,10 @@ const TimerText = tw.span`
   text-fg-muted
   text-[16.5px]
   font-normal
+  shrink-0
+`;
+
+const ResendButton = tw(Button)`
   shrink-0
 `;
 

--- a/apps/shop/src/components/common/Button.tsx
+++ b/apps/shop/src/components/common/Button.tsx
@@ -14,9 +14,9 @@ import tw from 'tailwind-styled-components';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /** 버튼 스타일 variant */
-  variant?: 'primary' | 'kakao' | 'naver';
+  variant?: 'primary' | 'outline' | 'kakao' | 'naver';
   /** 버튼 크기 */
-  size?: 'medium' | 'large';
+  size?: 'medium' | 'large' | 'xlarge';
 }
 
 /**
@@ -43,6 +43,14 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       );
     }
 
+    if (variant === 'outline') {
+      return (
+        <OutlineButton ref={ref} $size={size} {...props}>
+          {children}
+        </OutlineButton>
+      );
+    }
+
     return (
       <PrimaryButton ref={ref} $size={size} {...props}>
         {children}
@@ -54,7 +62,22 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 Button.displayName = 'Button';
 
 // Styled Components
-const PrimaryButton = tw.button<{ $size: 'medium' | 'large' }>`
+type ButtonSize = 'medium' | 'large' | 'xlarge';
+
+const getButtonHeight = (size: ButtonSize) => {
+  switch (size) {
+    case 'xlarge':
+      return 'h-[52px]';
+    case 'large':
+      return 'h-[52px]';
+    case 'medium':
+      return 'h-[44px]';
+    default:
+      return 'h-[52px]';
+  }
+};
+
+const PrimaryButton = tw.button<{ $size: ButtonSize }>`
   w-full
   px-4
   rounded-xl
@@ -72,10 +95,33 @@ const PrimaryButton = tw.button<{ $size: 'medium' | 'large' }>`
   text-fg-on-surface
   disabled:bg-bg-disabled
   disabled:text-fg-disabled
-  ${({ $size }) => ($size === 'large' ? 'h-[52px]' : 'h-[44px]')}
+  ${({ $size }) => getButtonHeight($size)}
 `;
 
-const KakaoButton = tw.button<{ $size: 'medium' | 'large' }>`
+const OutlineButton = tw.button<{ $size: ButtonSize }>`
+  px-3
+  rounded-xl
+  flex
+  items-center
+  justify-center
+  gap-1
+  text-[16.5px]
+  font-medium
+  leading-[22px]
+  transition-colors
+  hover:bg-bg-neutral-subtle
+  disabled:cursor-not-allowed
+  bg-white
+  text-fg-neutral
+  border
+  border-[var(--stroke-neutral)]
+  disabled:bg-bg-disabled
+  disabled:text-fg-disabled
+  disabled:border-transparent
+  ${({ $size }) => getButtonHeight($size)}
+`;
+
+const KakaoButton = tw.button<{ $size: ButtonSize }>`
   w-full
   px-4
   rounded-xl
@@ -93,10 +139,10 @@ const KakaoButton = tw.button<{ $size: 'medium' | 'large' }>`
   text-fg-neutral
   disabled:bg-bg-disabled
   disabled:text-fg-disabled
-  ${({ $size }) => ($size === 'large' ? 'h-[52px]' : 'h-[44px]')}
+  ${({ $size }) => getButtonHeight($size)}
 `;
 
-const NaverButton = tw.button<{ $size: 'medium' | 'large' }>`
+const NaverButton = tw.button<{ $size: ButtonSize }>`
   w-full
   px-4
   rounded-xl
@@ -114,5 +160,5 @@ const NaverButton = tw.button<{ $size: 'medium' | 'large' }>`
   text-white
   disabled:bg-bg-disabled
   disabled:text-fg-disabled
-  ${({ $size }) => ($size === 'large' ? 'h-[52px]' : 'h-[44px]')}
+  ${({ $size }) => getButtonHeight($size)}
 `;

--- a/apps/shop/src/routes/auth.complete-profile.tsx
+++ b/apps/shop/src/routes/auth.complete-profile.tsx
@@ -1,0 +1,442 @@
+/**
+ * 소셜 로그인 후 연락처 인증 페이지
+ *
+ * 소셜 로그인 후 휴대폰 인증을 통해 회원가입을 완료합니다.
+ *
+ * URL: /auth/complete-profile?token={pendingToken}&name={name}&returnUrl={returnUrl}
+ */
+
+import { createFileRoute } from '@tanstack/react-router';
+import { X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import SnappyModal, { useCurrentModal } from 'react-snappy-modal';
+import { toast } from 'sonner';
+import tw from 'tailwind-styled-components';
+
+import { OTPStep } from '@/components/auth/OTPStep';
+import { Button } from '@/components/common';
+import { useKeyboardHeight } from '@/hooks/useKeyboardHeight';
+import {
+  codeToArray,
+  EMPTY_OTP_CODE,
+  isValidPhoneNumber,
+  OTP_COUNTDOWN_SECONDS,
+  OTP_LENGTH,
+  redirectToSocialLogin,
+  saveTokens,
+} from '@/shared/auth';
+import { trpc } from '@/shared/trpc/trpc';
+
+export const Route = createFileRoute('/auth/complete-profile')({
+  component: CompleteProfilePage,
+});
+
+function CompleteProfilePage() {
+  const searchParams = new URLSearchParams(window.location.search);
+  const token = searchParams.get('token');
+  const returnUrl = searchParams.get('returnUrl') || '/';
+
+  const [phoneNumber, setPhoneNumber] = useState('');
+
+  const isPhoneValid = isValidPhoneNumber(phoneNumber);
+
+  // SMS 인증번호 요청
+  const requestVerificationMutation =
+    trpc.shopAuth.requestVerification.useMutation();
+
+  // 소셜 가입 완료
+  const completeSocialRegistrationMutation =
+    trpc.shopAuth.completeSocialRegistration.useMutation({
+      onSuccess: data => {
+        saveTokens(data);
+        toast.success('회원가입이 완료되었습니다!');
+        window.location.href = returnUrl;
+      },
+    });
+
+  const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPhoneNumber(e.target.value.replace(/\D/g, ''));
+  };
+
+  const handleClose = () => {
+    window.location.href = returnUrl;
+  };
+
+  // 카카오 로그인으로 리다이렉트
+  const handleTokenExpired = () => {
+    redirectToSocialLogin('kakao', returnUrl);
+  };
+
+  const handleRequestVerification = async () => {
+    if (!isPhoneValid || !token) return;
+
+    try {
+      const result = await requestVerificationMutation.mutateAsync({
+        phone: phoneNumber,
+      });
+
+      // OTP 바텀시트 열기
+      await SnappyModal.show(
+        <OTPBottomSheet
+          phoneNumber={phoneNumber}
+          pendingToken={token}
+          returnUrl={returnUrl}
+          initialCode={result.code}
+          completeSocialRegistrationMutation={
+            completeSocialRegistrationMutation
+          }
+          requestVerificationMutation={requestVerificationMutation}
+          onTokenExpired={handleTokenExpired}
+        />,
+        { position: 'bottom-center' }
+      );
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : '인증번호 발송에 실패했습니다'
+      );
+    }
+  };
+
+  // 토큰이 없으면 에러
+  if (!token) {
+    return (
+      <Container>
+        <PageWrapper>
+          <ErrorContainer>
+            <ErrorIconWrapper>!</ErrorIconWrapper>
+            <ErrorText>잘못된 접근입니다.</ErrorText>
+            <GoBackButton onClick={() => (window.location.href = '/')}>
+              홈으로 이동
+            </GoBackButton>
+          </ErrorContainer>
+        </PageWrapper>
+      </Container>
+    );
+  }
+
+  return (
+    <Container>
+      <PageWrapper>
+        {/* 헤더 */}
+        <Header>
+          <CloseButton onClick={handleClose}>
+            <X size={24} />
+          </CloseButton>
+        </Header>
+
+        <Content>
+          {/* 타이틀 */}
+          <TitleSection>
+            <Title>
+              안전한 거래를 위해
+              <br />
+              연락처 인증이 필요해요.
+            </Title>
+          </TitleSection>
+
+          {/* 연락처 입력 */}
+          <InputSection>
+            <InputLabel>연락처</InputLabel>
+            <PhoneInput
+              type="tel"
+              inputMode="numeric"
+              placeholder="010"
+              value={phoneNumber}
+              onChange={handlePhoneChange}
+              maxLength={11}
+            />
+          </InputSection>
+        </Content>
+
+        {/* 하단 버튼 */}
+        <BottomSection>
+          <Button
+            size="xlarge"
+            onClick={handleRequestVerification}
+            disabled={!isPhoneValid || requestVerificationMutation.isPending}
+          >
+            {requestVerificationMutation.isPending
+              ? '발송 중...'
+              : '연락처 인증'}
+          </Button>
+        </BottomSection>
+      </PageWrapper>
+    </Container>
+  );
+}
+
+/**
+ * OTP 인증 바텀시트
+ */
+interface OTPBottomSheetProps {
+  phoneNumber: string;
+  pendingToken: string;
+  returnUrl: string;
+  initialCode?: string;
+  completeSocialRegistrationMutation: ReturnType<
+    typeof trpc.shopAuth.completeSocialRegistration.useMutation
+  >;
+  requestVerificationMutation: ReturnType<
+    typeof trpc.shopAuth.requestVerification.useMutation
+  >;
+  onTokenExpired: () => void;
+}
+
+function OTPBottomSheet({
+  phoneNumber,
+  pendingToken,
+  initialCode,
+  completeSocialRegistrationMutation,
+  requestVerificationMutation,
+  onTokenExpired,
+}: OTPBottomSheetProps) {
+  const { resolveModal } = useCurrentModal();
+  const keyboardHeight = useKeyboardHeight();
+
+  const [otpCode, setOtpCode] = useState<string[]>(
+    initialCode ? codeToArray(initialCode) : EMPTY_OTP_CODE
+  );
+  const [countdown, setCountdown] = useState(OTP_COUNTDOWN_SECONDS);
+  const [error, setError] = useState<string | null>(null);
+
+  // 카운트다운 타이머
+  useEffect(() => {
+    if (countdown <= 0) return;
+
+    const timer = setInterval(() => {
+      setCountdown(prev => prev - 1);
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [countdown]);
+
+  const handleClose = () => {
+    resolveModal(null);
+  };
+
+  const handleVerify = async () => {
+    const code = otpCode.join('');
+    if (code.length !== OTP_LENGTH) {
+      setError(`인증번호 ${OTP_LENGTH}자리를 입력해주세요`);
+      return;
+    }
+
+    setError(null);
+
+    try {
+      await completeSocialRegistrationMutation.mutateAsync({
+        pendingToken,
+        phone: phoneNumber,
+        code,
+      });
+      // 성공 시 onSuccess에서 처리됨
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : '인증에 실패했습니다';
+
+      // pendingToken 만료 에러 처리
+      if (
+        errorMessage.includes('만료') ||
+        errorMessage.includes('expired') ||
+        errorMessage.includes('invalid')
+      ) {
+        resolveModal(null);
+        window.alert('인증 시간이 만료되었습니다. 다시 로그인해주세요.');
+        onTokenExpired();
+        return;
+      }
+
+      setError(errorMessage);
+    }
+  };
+
+  const handleResend = async () => {
+    setOtpCode(EMPTY_OTP_CODE);
+    setError(null);
+
+    try {
+      const result = await requestVerificationMutation.mutateAsync({
+        phone: phoneNumber,
+      });
+      setCountdown(OTP_COUNTDOWN_SECONDS);
+
+      // 개발환경에서 인증번호 자동 입력
+      if (result.code) {
+        setOtpCode(codeToArray(result.code));
+      }
+
+      toast.success('인증번호가 재발송되었습니다');
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : '인증번호 발송에 실패했습니다'
+      );
+    }
+  };
+
+  return (
+    <Overlay onClick={handleClose}>
+      <BottomSheetContainer
+        onClick={(e: React.MouseEvent) => e.stopPropagation()}
+        style={{ marginBottom: keyboardHeight }}
+      >
+        <OTPStep
+          otpCode={otpCode}
+          onOtpChange={setOtpCode}
+          onVerify={handleVerify}
+          onResend={handleResend}
+          onClose={handleClose}
+          countdown={countdown}
+          isLoading={completeSocialRegistrationMutation.isPending}
+          isResending={requestVerificationMutation.isPending}
+          error={error}
+        />
+      </BottomSheetContainer>
+    </Overlay>
+  );
+}
+
+// Styled Components
+const Container = tw.div`
+  min-h-screen
+  bg-bg-layer-base
+  max-w-[600px]
+  mx-auto
+`;
+
+const PageWrapper = tw.div`
+  min-h-screen
+  bg-white
+  flex
+  flex-col
+`;
+
+const Header = tw.header`
+  flex
+  items-center
+  h-16
+  px-5
+`;
+
+const CloseButton = tw.button`
+  w-6
+  h-6
+  flex
+  items-center
+  justify-center
+  text-fg-neutral
+`;
+
+const Content = tw.div`
+  flex-1
+  flex
+  flex-col
+  px-5
+  gap-5
+`;
+
+const TitleSection = tw.div`
+  flex
+  flex-col
+`;
+
+const Title = tw.h1`
+  text-fg-neutral
+  text-[21px]
+  font-bold
+  leading-7
+`;
+
+const InputSection = tw.div`
+  flex
+  flex-col
+  gap-2
+`;
+
+const InputLabel = tw.p`
+  text-fg-muted
+  text-[15px]
+  font-normal
+  leading-5
+`;
+
+const PhoneInput = tw.input`
+  h-[44px]
+  px-3
+  bg-bg-field
+  rounded-xl
+  outline
+  outline-1
+  outline-offset-[-1px]
+  outline-[var(--stroke-neutral)]
+  text-fg-neutral
+  text-[16.5px]
+  font-normal
+  placeholder:text-fg-placeholder
+  focus:outline-[var(--stroke-primary)]
+`;
+
+const BottomSection = tw.div`
+  px-5
+  py-5
+`;
+
+const ErrorContainer = tw.div`
+  flex-1
+  flex
+  flex-col
+  items-center
+  justify-center
+  gap-4
+`;
+
+const ErrorIconWrapper = tw.div`
+  w-12
+  h-12
+  rounded-full
+  bg-red-100
+  text-red-500
+  flex
+  items-center
+  justify-center
+  text-2xl
+  font-bold
+`;
+
+const ErrorText = tw.p`
+  text-gray-800
+  text-lg
+  text-center
+  px-4
+`;
+
+const GoBackButton = tw.button`
+  mt-4
+  px-6
+  py-2
+  bg-gray-100
+  text-gray-700
+  rounded-lg
+  hover:bg-gray-200
+  transition-colors
+`;
+
+const Overlay = tw.div`
+  fixed
+  inset-0
+  bg-black/40
+  flex
+  flex-col
+  justify-end
+  items-center
+  z-50
+`;
+
+const BottomSheetContainer = tw.div`
+  w-full
+  max-w-[600px]
+  flex
+  flex-col
+  overflow-hidden
+  transition-all
+  duration-200
+`;

--- a/apps/shop/src/routes/auth.kakao.callback.tsx
+++ b/apps/shop/src/routes/auth.kakao.callback.tsx
@@ -1,0 +1,172 @@
+/**
+ * 카카오 로그인 콜백 페이지
+ *
+ * 카카오 인증 후 리다이렉트되는 페이지입니다.
+ * Authorization Code를 받아서 백엔드 API로 토큰을 발급받고,
+ * 로그인 버튼을 눌렀던 원래 페이지로 돌아갑니다.
+ */
+
+import { createFileRoute } from '@tanstack/react-router';
+import { useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import tw from 'tailwind-styled-components';
+
+import { redirectToSocialLogin, saveTokens } from '@/shared/auth';
+import { trpc } from '@/shared/trpc/trpc';
+
+export const Route = createFileRoute('/auth/kakao/callback')({
+  component: KakaoCallbackPage,
+});
+
+function KakaoCallbackPage() {
+  const searchParams = new URLSearchParams(window.location.search);
+  const code = searchParams.get('code');
+  const error = searchParams.get('error');
+  const state = searchParams.get('state'); // 원래 페이지 URL
+
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const isCalledRef = useRef(false);
+
+  const kakaoLoginMutation = trpc.shopAuth.kakaoLogin.useMutation({
+    onSuccess: data => {
+      // 성공 시 재시도 카운터 초기화
+      sessionStorage.removeItem('kakaoLoginRetry');
+
+      if (data.status === 'complete') {
+        // 기존 회원 - 토큰 저장 후 원래 페이지로 이동
+        saveTokens(data);
+        toast.success('로그인 성공!');
+
+        const returnUrl = state || '/';
+        window.location.href = returnUrl;
+      } else {
+        // 신규 회원 - 휴대폰 인증 페이지로 이동
+        const returnUrl = state || '/';
+        const params = new URLSearchParams({
+          token: data.pendingToken,
+          returnUrl,
+        });
+        if (data.name) {
+          params.set('name', data.name);
+        }
+        window.location.href = `/auth/complete-profile?${params.toString()}`;
+      }
+    },
+    onError: err => {
+      // 인증 코드 만료/재사용 에러는 자동으로 카카오 로그인 재시도
+      if (err.message.includes('인증 코드가 유효하지 않거나 만료')) {
+        handleRetryKakaoLogin();
+        return;
+      }
+      setErrorMessage(err.message || '카카오 로그인에 실패했습니다');
+    },
+  });
+
+  const handleRetryKakaoLogin = () => {
+    // 무한 루프 방지: 최대 1회만 자동 재시도
+    const retryCount = Number(sessionStorage.getItem('kakaoLoginRetry') || 0);
+    if (retryCount >= 1) {
+      sessionStorage.removeItem('kakaoLoginRetry');
+      setErrorMessage('카카오 로그인에 실패했습니다. 다시 시도해주세요.');
+      return;
+    }
+    sessionStorage.setItem('kakaoLoginRetry', String(retryCount + 1));
+
+    const returnUrl = state || '/';
+    redirectToSocialLogin('kakao', returnUrl);
+  };
+
+  useEffect(() => {
+    // StrictMode 중복 호출 방지
+    if (isCalledRef.current) return;
+
+    if (error) {
+      setErrorMessage('카카오 로그인이 취소되었습니다');
+      return;
+    }
+
+    if (code) {
+      isCalledRef.current = true;
+      const redirectUri = `${window.location.origin}/auth/kakao/callback`;
+      kakaoLoginMutation.mutate({ code, redirectUri });
+    }
+  }, []);
+
+  const handleGoBack = () => {
+    const returnUrl = state || '/';
+    window.location.href = returnUrl;
+  };
+
+  if (errorMessage) {
+    return (
+      <Container>
+        <ErrorIcon>!</ErrorIcon>
+        <ErrorText>{errorMessage}</ErrorText>
+        <GoBackButton onClick={handleGoBack}>돌아가기</GoBackButton>
+      </Container>
+    );
+  }
+
+  return (
+    <Container>
+      <LoadingSpinner />
+      <LoadingText>카카오 로그인 중...</LoadingText>
+    </Container>
+  );
+}
+
+const Container = tw.div`
+  min-h-screen
+  flex
+  flex-col
+  items-center
+  justify-center
+  gap-4
+  bg-white
+`;
+
+const LoadingSpinner = tw.div`
+  w-10
+  h-10
+  border-4
+  border-gray-200
+  border-t-yellow-400
+  rounded-full
+  animate-spin
+`;
+
+const LoadingText = tw.p`
+  text-gray-600
+  text-lg
+`;
+
+const ErrorIcon = tw.div`
+  w-12
+  h-12
+  rounded-full
+  bg-red-100
+  text-red-500
+  flex
+  items-center
+  justify-center
+  text-2xl
+  font-bold
+`;
+
+const ErrorText = tw.p`
+  text-gray-800
+  text-lg
+  text-center
+  px-4
+`;
+
+const GoBackButton = tw.button`
+  mt-4
+  px-6
+  py-2
+  bg-gray-100
+  text-gray-700
+  rounded-lg
+  hover:bg-gray-200
+  transition-colors
+`;

--- a/apps/shop/src/shared/auth/auth.constants.ts
+++ b/apps/shop/src/shared/auth/auth.constants.ts
@@ -1,0 +1,23 @@
+/**
+ * 인증 관련 상수
+ */
+
+/** OTP 인증번호 길이 */
+export const OTP_LENGTH = 6;
+
+/** OTP 만료 시간 (초) */
+export const OTP_COUNTDOWN_SECONDS = 180;
+
+/** 빈 OTP 코드 배열 */
+export const EMPTY_OTP_CODE = Array(OTP_LENGTH).fill('') as string[];
+
+/** 휴대폰 번호 유효성 검사 정규식 */
+export const PHONE_REGEX = /^01[0-9]{8,9}$/;
+
+/** 휴대폰 번호 유효성 검사 */
+export const isValidPhoneNumber = (phone: string): boolean =>
+  PHONE_REGEX.test(phone);
+
+/** OTP 코드를 문자열에서 배열로 변환 */
+export const codeToArray = (code: string): string[] =>
+  code.split('').concat(EMPTY_OTP_CODE).slice(0, OTP_LENGTH);

--- a/apps/shop/src/shared/auth/index.ts
+++ b/apps/shop/src/shared/auth/index.ts
@@ -1,0 +1,3 @@
+export * from './auth.constants';
+export * from './social-login';
+export * from './token';

--- a/apps/shop/src/shared/auth/social-login.ts
+++ b/apps/shop/src/shared/auth/social-login.ts
@@ -1,0 +1,124 @@
+/**
+ * 소셜 로그인 유틸리티
+ *
+ * 다양한 소셜 로그인 제공자를 지원하는 유틸리티입니다.
+ * 새로운 제공자 추가 시 SOCIAL_PROVIDERS에 설정을 추가하면 됩니다.
+ */
+
+/** 소셜 로그인 제공자 타입 */
+export type SocialProvider = 'kakao' | 'naver' | 'google' | 'apple';
+
+interface SocialProviderConfig {
+  /** OAuth 인증 URL */
+  authUrl: string;
+  /** 클라이언트 ID 환경변수 키 */
+  clientIdEnvKey: string;
+  /** 콜백 경로 */
+  callbackPath: string;
+  /** 추가 파라미터 */
+  additionalParams?: Record<string, string>;
+}
+
+/** 소셜 로그인 제공자 설정 */
+const SOCIAL_PROVIDERS: Record<SocialProvider, SocialProviderConfig> = {
+  kakao: {
+    authUrl: 'https://kauth.kakao.com/oauth/authorize',
+    clientIdEnvKey: 'VITE_KAKAO_CLIENT_ID',
+    callbackPath: '/auth/kakao/callback',
+  },
+  naver: {
+    authUrl: 'https://nid.naver.com/oauth2.0/authorize',
+    clientIdEnvKey: 'VITE_NAVER_CLIENT_ID',
+    callbackPath: '/auth/naver/callback',
+  },
+  google: {
+    authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+    clientIdEnvKey: 'VITE_GOOGLE_CLIENT_ID',
+    callbackPath: '/auth/google/callback',
+    additionalParams: {
+      scope: 'email profile',
+    },
+  },
+  apple: {
+    authUrl: 'https://appleid.apple.com/auth/authorize',
+    clientIdEnvKey: 'VITE_APPLE_CLIENT_ID',
+    callbackPath: '/auth/apple/callback',
+    additionalParams: {
+      scope: 'name email',
+      response_mode: 'form_post',
+    },
+  },
+};
+
+/**
+ * 소셜 로그인 URL 생성
+ *
+ * @param provider - 소셜 로그인 제공자
+ * @param returnUrl - 로그인 완료 후 돌아갈 URL (기본값: 현재 페이지)
+ * @returns OAuth 인증 URL
+ */
+export function buildSocialLoginUrl(
+  provider: SocialProvider,
+  returnUrl?: string
+): string | null {
+  const config = SOCIAL_PROVIDERS[provider];
+  if (!config) {
+    console.error(`Unknown social provider: ${provider}`);
+    return null;
+  }
+
+  const clientId = import.meta.env[config.clientIdEnvKey];
+  if (!clientId) {
+    console.error(`Missing env variable: ${config.clientIdEnvKey}`);
+    return null;
+  }
+
+  const redirectUri = `${window.location.origin}${config.callbackPath}`;
+  const state = returnUrl ?? window.location.href;
+
+  const url = new URL(config.authUrl);
+  url.searchParams.set('client_id', clientId);
+  url.searchParams.set('redirect_uri', redirectUri);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('state', state);
+
+  // 추가 파라미터 설정
+  if (config.additionalParams) {
+    Object.entries(config.additionalParams).forEach(([key, value]) => {
+      url.searchParams.set(key, value);
+    });
+  }
+
+  return url.toString();
+}
+
+/**
+ * 소셜 로그인 실행
+ *
+ * @param provider - 소셜 로그인 제공자
+ * @param returnUrl - 로그인 완료 후 돌아갈 URL
+ */
+export function redirectToSocialLogin(
+  provider: SocialProvider,
+  returnUrl?: string
+): void {
+  const url = buildSocialLoginUrl(provider, returnUrl);
+
+  if (url) {
+    window.location.href = url;
+  }
+}
+
+/**
+ * 소셜 로그인 제공자 지원 여부 확인
+ *
+ * @param provider - 확인할 제공자
+ * @returns 지원 여부
+ */
+export function isSocialProviderSupported(provider: SocialProvider): boolean {
+  const config = SOCIAL_PROVIDERS[provider];
+  if (!config) return false;
+
+  const clientId = import.meta.env[config.clientIdEnvKey];
+  return !!clientId;
+}

--- a/apps/shop/src/shared/auth/token.ts
+++ b/apps/shop/src/shared/auth/token.ts
@@ -1,0 +1,64 @@
+/**
+ * 토큰 관리 유틸리티
+ *
+ * localStorage를 사용한 인증 토큰 관리
+ */
+
+const ACCESS_TOKEN_KEY = 'accessToken';
+const REFRESH_TOKEN_KEY = 'refreshToken';
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
+/**
+ * 토큰 저장
+ */
+export function saveTokens(tokens: AuthTokens): void {
+  localStorage.setItem(ACCESS_TOKEN_KEY, tokens.accessToken);
+  localStorage.setItem(REFRESH_TOKEN_KEY, tokens.refreshToken);
+}
+
+/**
+ * 토큰 조회
+ */
+export function getTokens(): AuthTokens | null {
+  const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
+  const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY);
+
+  if (!accessToken || !refreshToken) {
+    return null;
+  }
+
+  return { accessToken, refreshToken };
+}
+
+/**
+ * Access Token 조회
+ */
+export function getAccessToken(): string | null {
+  return localStorage.getItem(ACCESS_TOKEN_KEY);
+}
+
+/**
+ * Refresh Token 조회
+ */
+export function getRefreshToken(): string | null {
+  return localStorage.getItem(REFRESH_TOKEN_KEY);
+}
+
+/**
+ * 토큰 삭제 (로그아웃)
+ */
+export function clearTokens(): void {
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  localStorage.removeItem(REFRESH_TOKEN_KEY);
+}
+
+/**
+ * 로그인 상태 확인
+ */
+export function isLoggedIn(): boolean {
+  return !!getAccessToken();
+}


### PR DESCRIPTION
## Summary
- 카카오 OAuth 콜백 페이지 및 소셜 로그인 후 연락처 인증 페이지 구현
- 로그인 바텀시트에 실제 SMS 인증 API 연동
- 인증 관련 유틸리티 모듈화 (`shared/auth/`)

## Changes
### 신규 파일
- `auth.kakao.callback.tsx`: 카카오 OAuth 콜백 처리
- `auth.complete-profile.tsx`: 소셜 로그인 후 연락처 인증
- `shared/auth/`: 인증 관련 유틸리티 모듈
  - `auth.constants.ts`: OTP 상수, 전화번호 검증
  - `social-login.ts`: 소셜 로그인 설정 및 리다이렉트
  - `token.ts`: 토큰 저장/조회/삭제

### 수정 파일
- `LoginBottomSheet.tsx`: 실제 SMS API 연동
- `LoginStep.tsx`: 소셜 로그인 유틸리티 사용
- `OTPStep.tsx`: 피그마 디자인 맞춤 수정
- `Button.tsx`: `outline` variant, `xlarge` size 추가

## Dependencies
- 백엔드 PR #147 머지 필요 (카카오 로그인 API)

## Test plan
- [ ] 카카오 로그인 버튼 클릭 → 카카오 인증 페이지 이동
- [ ] 카카오 인증 완료 → 콜백 페이지에서 토큰 처리
- [ ] 신규 회원 → 연락처 인증 페이지 이동
- [ ] SMS 인증번호 발송 및 검증
- [ ] 기존 회원 → 바로 로그인 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)