### PR TITLE
FIX: Dockerfile 빌드 순서 수정 (option-selector 먼저 빌드)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -16,9 +16,12 @@ RUN yarn install --frozen-lockfile
 COPY apps/api ./apps/api
 COPY packages/option-selector ./packages/option-selector
 
-# Generate environment variables and build
-WORKDIR /app/apps/api
+# Build option-selector package first
+WORKDIR /app/packages/option-selector
+RUN yarn build
 
+# Build API
+WORKDIR /app/apps/api
 RUN yarn build
 
 FROM node:22.16-alpine


### PR DESCRIPTION
## Summary
- Dockerfile에서 option-selector 패키지를 먼저 빌드하도록 수정
- API 빌드 시 의존성 문제 해결

## 주요 변경사항

### Dockerfile 빌드 순서 수정
- API 빌드 전에 `packages/option-selector` 패키지를 먼저 빌드
- API가 option-selector 패키지에 의존하므로 빌드 순서 조정 필요

## Before
```dockerfile
WORKDIR /app/apps/api
RUN yarn build
```

## After
```dockerfile
# Build option-selector package first
WORKDIR /app/packages/option-selector
RUN yarn build

# Build API
WORKDIR /app/apps/api
RUN yarn build
```

## Test plan
- [ ] Docker 빌드 성공 확인
- [ ] API 컨테이너 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)