### PR TITLE
FEAT: 주문 페이지 로그인 상태에 따른 UI 분기 처리

### DIFF
--- a/apps/shop/src/components/new-order/AuthPromptSection.tsx
+++ b/apps/shop/src/components/new-order/AuthPromptSection.tsx
@@ -1,0 +1,45 @@
+/**
+ * AuthPromptSection - 미로그인 상태 인증 안내 섹션
+ *
+ * 미로그인 사용자에게 인증/로그인을 유도하는 안내 메시지와 버튼을 표시합니다.
+ *
+ * Usage:
+ * <AuthPromptSection onAuthClick={() => openLoginBottomSheet()} />
+ */
+
+import tw from 'tailwind-styled-components';
+
+import { Button } from '@/components/common/Button';
+
+export interface AuthPromptSectionProps {
+  /** 인증하기 버튼 클릭 핸들러 */
+  onAuthClick: () => void;
+}
+
+export function AuthPromptSection({ onAuthClick }: AuthPromptSectionProps) {
+  return (
+    <Section>
+      <Message>
+        연락처 인증 또는 로그인 후
+        <br />
+        주문을 진행해 주세요.
+      </Message>
+      <Button onClick={onAuthClick}>인증하기</Button>
+    </Section>
+  );
+}
+
+const Section = tw.section`
+  p-5
+  bg-white
+  flex
+  flex-col
+  gap-4
+`;
+
+const Message = tw.p`
+  text-fg-neutral
+  text-[21px]
+  font-bold
+  leading-7
+`;

--- a/apps/shop/src/components/new-order/index.ts
+++ b/apps/shop/src/components/new-order/index.ts
@@ -1,3 +1,4 @@
+export * from './AuthPromptSection';
 export * from './HotelProductSection';
 export * from './UserInputSection';
 export * from './PaymentMethodSection';

--- a/apps/shop/src/routes/new-order.$orderNumber.tsx
+++ b/apps/shop/src/routes/new-order.$orderNumber.tsx
@@ -10,13 +10,15 @@ import * as PortOne from '@portone/browser-sdk/v2';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import axios from 'axios';
 import dayjs from 'dayjs';
-import { ArrowLeft } from 'lucide-react';
+import { X } from 'lucide-react';
 import { Suspense, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import tw from 'tailwind-styled-components';
 
+import { openLoginBottomSheet } from '@/components/auth/LoginBottomSheet';
 import {
+  AuthPromptSection,
   HotelProductSection,
   UserInputSection,
   PaymentMethodSection,
@@ -27,6 +29,7 @@ import {
 } from '@/components/new-order';
 import { API_BASEURL } from '@/constants';
 import { trpc } from '@/shared';
+import { useAuthStore } from '@/store/authStore';
 
 export interface NewOrderFormData {
   userName: string;
@@ -52,6 +55,7 @@ function NewOrderPage() {
 
 function NewOrderContent({ orderNumber }: { orderNumber: string }) {
   const navigate = useNavigate();
+  const { isLoggedIn } = useAuthStore();
   const [data] = trpc.shopOrder.getTmpOrder.useSuspenseQuery({ orderNumber });
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -65,8 +69,15 @@ function NewOrderContent({ orderNumber }: { orderNumber: string }) {
     },
   });
 
-  const handleBack = () => {
-    navigate({ to: '/' });
+  const handleAuthClick = async () => {
+    const result = await openLoginBottomSheet();
+    if (result?.success) {
+      window.location.reload();
+    }
+  };
+
+  const handleClose = () => {
+    window.history.back();
   };
 
   const getPortOnePayMethod = (
@@ -165,14 +176,16 @@ function NewOrderContent({ orderNumber }: { orderNumber: string }) {
     <FormProvider {...methods}>
       <Container>
         <Header>
-          <BackButton onClick={handleBack}>
-            <ArrowLeft size={24} />
-          </BackButton>
+          <CloseButton onClick={handleClose}>
+            <X size={24} />
+          </CloseButton>
           <HeaderTitle>주문</HeaderTitle>
           <HeaderSpacer />
         </Header>
 
         <ContentWrapper>
+          {!isLoggedIn && <AuthPromptSection onAuthClick={handleAuthClick} />}
+
           <HotelProductSection
             thumbnailUrl={data.product.thumbnailUrl ?? null}
             productName={data.product.name}
@@ -183,20 +196,25 @@ function NewOrderContent({ orderNumber }: { orderNumber: string }) {
             checkOutTime={data.product.checkOutTime}
           />
 
-          <UserInputSection />
-
-          <PaymentMethodSection />
+          {isLoggedIn && (
+            <>
+              <UserInputSection />
+              <PaymentMethodSection />
+            </>
+          )}
 
           <PaymentAmountSection
             productAmount={data.totalAmount}
             totalAmount={data.totalAmount}
           />
 
-          <PaymentAgreementSection
-            totalAmount={data.totalAmount}
-            onSubmit={handleSubmit}
-            isSubmitting={isSubmitting}
-          />
+          {isLoggedIn && (
+            <PaymentAgreementSection
+              totalAmount={data.totalAmount}
+              onSubmit={handleSubmit}
+              isSubmitting={isSubmitting}
+            />
+          )}
         </ContentWrapper>
       </Container>
     </FormProvider>
@@ -245,7 +263,7 @@ const Header = tw.header`
   gap-5
 `;
 
-const BackButton = tw.button`
+const CloseButton = tw.button`
   w-6
   h-6
   flex


### PR DESCRIPTION
## Summary
- 미로그인 상태: 인증 안내 섹션 + 상품 정보 + 결제 금액만 표시
- 로그인 상태: 전체 주문 폼 (주문자 정보, 결제 수단, 약관 동의, 결제 버튼) 표시
- `AuthPromptSection` 컴포넌트 신규 추가
- 헤더 닫기 버튼 X 아이콘으로 변경, `window.history.back()` 동작

## Changes
- `apps/shop/src/components/new-order/AuthPromptSection.tsx` - 미로그인 인증 안내 섹션
- `apps/shop/src/components/new-order/index.ts` - export 추가
- `apps/shop/src/routes/new-order.$orderNumber.tsx` - 로그인 상태 분기 처리

## Test plan
- [ ] 미로그인 상태에서 주문 페이지 접근 시 인증 안내 UI 표시 확인
- [ ] 인증하기 버튼 클릭 시 로그인 바텀시트 표시 확인
- [ ] 로그인 후 전체 주문 폼 표시 확인
- [ ] X 버튼 클릭 시 뒤로가기 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)