### PR TITLE
FIX: 백오피스 로그인 비밀번호 검증 버그 수정

### DIFF
--- a/apps/api/src/module/backoffice/auth/backoffice.auth.service.ts
+++ b/apps/api/src/module/backoffice/auth/backoffice.auth.service.ts
@@ -41,10 +41,10 @@ export class BackofficeAuthService {
     const admin = await this.repositoryProvider.AdminRepository.findOneByOrFail(
       { email }
     ).catch(() => {
-      throw new NotFoundException('Admin not found');
+      throw new NotFoundException('존재하지 않는 계정입니다');
     });
-    if (!admin.checkPassword(password)) {
-      throw new UnauthorizedException('Invalid password');
+    if (!(await admin.checkPassword(password))) {
+      throw new UnauthorizedException('비밀번호가 틀렸습니다');
     }
     const payload: AdminAuthPayload = { email: admin.email, id: admin.id };
     const accessToken = jwtService.sign(
@@ -66,8 +66,8 @@ export class BackofficeAuthService {
         refreshToken,
         ConfigProvider.auth.jwt.backoffice.refresh
       );
-    } catch (e) {
-      throw new UnauthorizedException('Invalid refresh token');
+    } catch {
+      throw new UnauthorizedException('유효하지 않은 토큰입니다');
     }
 
     // 사용자가 여전히 존재하는지 확인
@@ -77,7 +77,7 @@ export class BackofficeAuthService {
         email: payload.email,
       }
     ).catch(() => {
-      throw new NotFoundException('Admin not found');
+      throw new NotFoundException('존재하지 않는 계정입니다');
     });
 
     // 새로운 access token 발급

--- a/apps/backoffice/src/components/login/LoginForm.tsx
+++ b/apps/backoffice/src/components/login/LoginForm.tsx
@@ -33,7 +33,7 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
     },
     onError: (error) => {
       console.error('로그인 실패:', error);
-      alert('로그인 실패');
+      alert(error.message || '로그인에 실패했습니다');
     },
   });
 


### PR DESCRIPTION
## Summary
- `checkPassword()` async 함수에 await 누락으로 비밀번호 검증이 되지 않던 **심각한 보안 버그 수정**
- 백엔드 에러 메시지 한글화 (존재하지 않는 계정, 비밀번호 틀림, 유효하지 않은 토큰)
- 프론트엔드에서 서버 에러 메시지를 alert으로 표시하도록 개선

## 변경 파일
- `apps/api/src/module/backoffice/auth/backoffice.auth.service.ts`
- `apps/backoffice/src/components/login/LoginForm.tsx`

## 버그 원인
```typescript
// BEFORE - Promise 객체는 truthy이므로 !Promise는 항상 false
if (!admin.checkPassword(password)) {
  throw new UnauthorizedException('Invalid password');
}

// AFTER - await로 실제 boolean 값을 받아서 검증
if (!(await admin.checkPassword(password))) {
  throw new UnauthorizedException('비밀번호가 틀렸습니다');
}
```

## Test plan
- [ ] 틀린 비밀번호로 로그인 시도 → "비밀번호가 틀렸습니다" 에러 확인
- [ ] 존재하지 않는 이메일로 로그인 시도 → "존재하지 않는 계정입니다" 에러 확인
- [ ] 올바른 계정으로 로그인 시도 → 정상 로그인 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)