### PR TITLE
FIX: CORS 정규식 패턴 수정 - 루트 도메인 허용

### DIFF
--- a/apps/api/config/default.js
+++ b/apps/api/config/default.js
@@ -62,8 +62,8 @@ module.exports = {
         'https://www.yestravel.kr',
       ];
       
-      // *.yestravel.co.kr 패턴 매칭 (모든 서브도메인 허용)
-      const productionPattern = /^https:\/\/[a-zA-Z0-9-]+\.yestravel\.co\.kr$/;
+      // *.yestravel.co.kr 및 yestravel.co.kr 패턴 매칭 (서브도메인 optional)
+      const productionPattern = /^https:\/\/([a-zA-Z0-9-]+\.)?yestravel\.co\.kr$/;
       
       // origin이 없는 경우 (같은 origin 요청)
       if (!origin) {

--- a/apps/api/config/development.js
+++ b/apps/api/config/development.js
@@ -9,8 +9,8 @@ module.exports = {
         'http://localhost:3000', // 동일 origin
       ];
       
-      // *.dev.yestravel.co.kr 패턴 매칭
-      const devPattern = /^https?:\/\/[a-zA-Z0-9-]+\.dev\.yestravel\.co\.kr$/;
+      // *.dev.yestravel.co.kr 및 dev.yestravel.co.kr 패턴 매칭
+      const devPattern = /^https?:\/\/([a-zA-Z0-9-]+\.)?dev\.yestravel\.co\.kr$/;
       
       // origin이 없는 경우 (같은 origin 요청, Postman 등)
       if (!origin) {


### PR DESCRIPTION
## Summary
- 서브도메인 없이 루트 도메인으로 요청 시 CORS 에러 발생하는 버그 수정
- `yestravel.co.kr`, `dev.yestravel.co.kr` 도메인 허용

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `default.js` | `([a-zA-Z0-9-]+\.)?yestravel\.co\.kr` 패턴으로 수정 |
| `development.js` | `([a-zA-Z0-9-]+\.)?dev\.yestravel\.co\.kr` 패턴으로 수정 |

## Test plan
- [ ] `https://yestravel.co.kr` → API 호출 CORS 통과 확인
- [ ] `https://dev.yestravel.co.kr` → API 호출 CORS 통과 확인
- [ ] 기존 서브도메인(`backoffice.yestravel.co.kr` 등) 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)