### PR TITLE
FEAT: SMTNT 알림톡 연동 구현

### DIFF
--- a/apps/api/config/default.js
+++ b/apps/api/config/default.js
@@ -94,4 +94,9 @@ module.exports = {
     clientId: process.env.KAKAO_CLIENT_ID,
     clientSecret: process.env.KAKAO_CLIENT_SECRET,
   },
+  smtnt: {
+    userId: process.env.SMTNT_ID,
+    senderKey: process.env.SMTNT_PROFILE_KEY,
+    callback: process.env.SMTNT_SEND_PHONE,
+  },
 };

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -39,6 +39,15 @@ type KakaoConfigType = {
   clientSecret: string;
 };
 
+type SmtntConfigType = {
+  /** API URL의 사용자 ID */
+  userId: string;
+  /** 카카오 발신 프로필 키 */
+  senderKey: string;
+  /** 발신번호 */
+  callback: string;
+};
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const ConfigProvider = {
   stage: config.get<string>('stage'),
@@ -67,4 +76,5 @@ export const ConfigProvider = {
   kakao: config.has('kakao')
     ? config.get<KakaoConfigType>('kakao')
     : { clientId: '', clientSecret: '' },
+  smtnt: config.has('smtnt') ? config.get<SmtntConfigType>('smtnt') : undefined,
 } as const;

--- a/apps/api/src/module/shared/notification/notification.module.ts
+++ b/apps/api/src/module/shared/notification/notification.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { SmtntService } from './smtnt/smtnt.service';
+
+/**
+ * NotificationModule - 알림 발송 모듈
+ *
+ * 알림톡, SMS 등 알림 발송 서비스를 제공합니다.
+ */
+@Module({
+  providers: [SmtntService],
+  exports: [SmtntService],
+})
+export class NotificationModule {}

--- a/apps/api/src/module/shared/notification/smtnt/smtnt.service.ts
+++ b/apps/api/src/module/shared/notification/smtnt/smtnt.service.ts
@@ -1,0 +1,102 @@
+import { Injectable, Logger } from '@nestjs/common';
+import axios from 'axios';
+import FormData from 'form-data';
+import { ConfigProvider } from '@src/config';
+import type { SmtntAlimtalkRequest, SmtntResponse } from './smtnt.type';
+
+/**
+ * SmtntService - SMTNT 알림톡 발송 서비스
+ *
+ * SMTNT API를 통해 카카오 알림톡을 발송합니다.
+ * API URL: https://api2.msgagent.com/api/webshot/send/kakao/AT/{id}
+ */
+@Injectable()
+export class SmtntService {
+  private readonly logger = new Logger(SmtntService.name);
+  private readonly baseUrl =
+    'https://api2.msgagent.com/api/webshot/send/kakao/AT';
+
+  /**
+   * 알림톡 발송
+   * @param request 알림톡 발송 요청
+   * @returns SMTNT API 응답
+   */
+  async sendAlimtalk(request: SmtntAlimtalkRequest): Promise<SmtntResponse> {
+    const config = ConfigProvider.smtnt;
+
+    if (!config) {
+      this.logger.warn('SMTNT 설정이 없습니다. 알림톡이 발송되지 않습니다.');
+      return { result_code: 'SKIP', cmid: undefined };
+    }
+
+    const formData = new FormData();
+    formData.append('PHONE', request.phone);
+    formData.append('MSG', request.message);
+    formData.append('SENDER_KEY', config.senderKey);
+    formData.append('TEMPLATE_CODE', request.templateCode);
+    formData.append('FAILED_TYPE', request.failedType ?? 'N');
+    formData.append('CALLBACK', request.callback ?? config.callback);
+
+    if (request.failedMessage) {
+      formData.append('FAILED_MSG', request.failedMessage);
+    }
+
+    const url = `${this.baseUrl}/${config.userId}`;
+
+    try {
+      const response = await axios.post<SmtntResponse>(url, formData, {
+        headers: formData.getHeaders(),
+        timeout: 10000,
+      });
+
+      const { result_code, cmid } = response.data;
+
+      // result_code 0이 성공
+      if (result_code === '0') {
+        this.logger.log(
+          `알림톡 발송 성공: phone=${request.phone}, cmid=${cmid}`
+        );
+      } else {
+        const errorMessage = this.getErrorMessage(result_code);
+        this.logger.error(
+          `알림톡 발송 실패: phone=${request.phone}, result_code=${result_code}, error=${errorMessage}`
+        );
+      }
+
+      return response.data;
+    } catch (error) {
+      this.logger.error(
+        `알림톡 발송 실패: phone=${request.phone}`,
+        error instanceof Error ? error.message : error
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * SMTNT result_code에 대한 에러 메시지 반환
+   */
+  private getErrorMessage(resultCode: string): string {
+    const errorMessages: Record<string, string> = {
+      '0': '성공',
+      '100': '허용되지 않은 형식',
+      '101': '허용되지 않은 IP',
+      '102': '허용되지 않은 파일 형식',
+      '103': '허용되지 않은 사용자 아이디',
+      '200': '필수 요청 값 누락',
+      '300': '잘못된 요청 값',
+      '301': '잘못된 요청 값(메시지 타입)',
+      '302': '잘못된 요청 값(광고성 메시지 표시)',
+      '304': '잘못된 요청 값(전송시간)',
+      '305': '잘못된 요청 값(휴대전화번호)',
+      '306': '잘못된 요청 값(데이터 없음)',
+      '400': '데이터 길이 제한 초과',
+      '401': '데이터 길이 제한 초과(제목)',
+      '402': '데이터 길이 제한 초과(내용)',
+      '403': '데이터 길이 제한 초과(대체메시지)',
+      '600': 'JSON 파싱 오류',
+      '999': '시스템 오류',
+    };
+    return errorMessages[resultCode] ?? `알 수 없는 오류 (${resultCode})`;
+  }
+}

--- a/apps/api/src/module/shared/notification/smtnt/smtnt.type.ts
+++ b/apps/api/src/module/shared/notification/smtnt/smtnt.type.ts
@@ -1,0 +1,34 @@
+/**
+ * SMTNT 알림톡 API 타입 정의
+ */
+
+/** 대체 메시지 타입 */
+export type SmtntFailedType = 'SMS' | 'LMS' | 'N';
+
+/**
+ * SMTNT 알림톡 전송 요청
+ */
+export interface SmtntAlimtalkRequest {
+  /** 수신 휴대폰 번호 */
+  phone: string;
+  /** 발송 메시지 (최대 1000자) */
+  message: string;
+  /** 알림톡 템플릿 코드 */
+  templateCode: string;
+  /** 대체 메시지 타입 (SMS/LMS/N) */
+  failedType?: SmtntFailedType;
+  /** 대체 메시지 내용 */
+  failedMessage?: string;
+  /** 발신번호 (설정 기본값 사용 시 생략) */
+  callback?: string;
+}
+
+/**
+ * SMTNT API 응답
+ */
+export interface SmtntResponse {
+  /** 결과 코드 */
+  result_code: string;
+  /** 메시지 아이디 */
+  cmid?: string;
+}

--- a/apps/api/src/module/shared/shared.module.ts
+++ b/apps/api/src/module/shared/shared.module.ts
@@ -2,10 +2,11 @@ import { Global, Module } from '@nestjs/common';
 import { RequestModule } from '@src/module/shared/request/request.module';
 import { TransactionModule } from '@src/module/shared/transaction/transaction.module';
 import { AwsModule } from '@src/module/shared/aws/aws.module';
+import { NotificationModule } from '@src/module/shared/notification/notification.module';
 
 @Global()
 @Module({
-  imports: [RequestModule, TransactionModule, AwsModule],
-  exports: [RequestModule, TransactionModule, AwsModule],
+  imports: [RequestModule, TransactionModule, AwsModule, NotificationModule],
+  exports: [RequestModule, TransactionModule, AwsModule, NotificationModule],
 })
 export class SharedModule {}

--- a/apps/api/src/module/shop/auth/shop.auth.service.ts
+++ b/apps/api/src/module/shop/auth/shop.auth.service.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   Injectable,
+  Logger,
   UnauthorizedException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
@@ -22,6 +23,7 @@ import {
 } from './shop.auth.dto';
 import { KakaoService } from './kakao/kakao.service';
 import { SocialProviderEnum } from '@src/module/backoffice/domain/shop/social-account.entity';
+import { SmtntService } from '@src/module/shared/notification/smtnt/smtnt.service';
 
 const jwtService = new JwtService();
 
@@ -33,9 +35,12 @@ const jwtService = new JwtService();
  */
 @Injectable()
 export class ShopAuthService {
+  private readonly logger = new Logger(ShopAuthService.name);
+
   constructor(
     private readonly repositoryProvider: RepositoryProvider,
-    private readonly kakaoService: KakaoService
+    private readonly kakaoService: KakaoService,
+    private readonly smtntService: SmtntService
   ) {}
 
   /**
@@ -60,12 +65,21 @@ export class ShopAuthService {
         expiresAt,
       });
 
-    // TODO: SMTNT 알림톡 서비스 연동
-    // await this.alrimtalkService.send({
-    //   phone: input.phone,
-    //   templateCode: 'SHOP_VERIFICATION',
-    //   variables: { code },
-    // });
+    // SMTNT 알림톡 발송
+    try {
+      await this.smtntService.sendAlimtalk({
+        phone: input.phone,
+        message: `[예스트래블] 인증번호 안내\n\n인증번호: ${code}\n\n인증번호는 3분간 유효합니다.\n본인이 요청하지 않은 경우 무시해주세요.`,
+        templateCode: 'SHOP_VERIFICATION',
+        failedType: 'SMS',
+        failedMessage: `[예스트래블] 인증번호: ${code} (3분간 유효)`,
+      });
+    } catch (error) {
+      this.logger.error(
+        `인증번호 알림톡 발송 실패: ${input.phone}`,
+        error instanceof Error ? error.message : error
+      );
+    }
 
     const response: RequestVerificationResponse = {
       id: verification.id,


### PR DESCRIPTION
## 📋 Summary

- ✨ Shop 인증 시 인증번호를 SMTNT 알림톡 API로 발송하는 기능 구현
- ✨ NotificationModule 및 SmtntService 생성

## 🔄 주요 변경사항

### 🖥️ Backend

**SmtntService:**
- SMTNT API (`https://api2.msgagent.com/api/webshot/send/kakao/AT/{id}`)를 통한 알림톡 발송
- multipart/form-data POST 요청 구현
- result_code별 에러 메시지 처리

**ShopAuthService:**
- 인증번호 요청 시 알림톡 발송 로직 추가
- 발송 실패 시 에러 로깅 (사용자 경험 보장을 위해 예외 미전파)

## 📁 변경된 파일

- `config/default.js` - SMTNT 환경변수 설정 추가
- `src/config.ts` - SmtntConfigType 타입 추가
- `src/module/shared/shared.module.ts` - NotificationModule import
- `src/module/shared/notification/notification.module.ts` - 신규 모듈
- `src/module/shared/notification/smtnt/smtnt.service.ts` - SMTNT API 서비스
- `src/module/shared/notification/smtnt/smtnt.type.ts` - 타입 정의
- `src/module/shop/auth/shop.auth.service.ts` - 알림톡 발송 로직 추가

## 🎯 영향 범위

### ✅ Breaking Changes
- 없음

### ✅ 사이드이펙트 검토
- 기존 인증 로직 동작 변경 없음
- 알림톡 발송 실패 시에도 인증번호 정상 응답

## ⚙️ 환경변수

```bash
SMTNT_ID=사용자아이디
SMTNT_PROFILE_KEY=카카오발신프로필키
SMTNT_SEND_PHONE=발신번호
```

## 📝 참고사항

- SMTNT 계정 인증 확인 필요 (현재 result_code=103 발생)
- 템플릿코드 `SHOP_VERIFICATION`은 예시, 실제 등록된 코드로 변경 필요

🤖 Generated with [Claude Code](https://claude.ai/code)