### PR TITLE
FIX: Migration 컬럼명 snake_case로 수정 및 문서화

### DIFF
--- a/.claude/skills/Backend/migration.md
+++ b/.claude/skills/Backend/migration.md
@@ -45,6 +45,26 @@ yarn migration:run      # 실행
 yarn migration:revert   # 되돌리기 (가장 최근 1개)
 ```
 
+## 네이밍 규칙
+
+| 항목 | 규칙 | 예시 |
+|------|------|------|
+| 테이블명 | snake_case | `tmp_order`, `hotel_template` |
+| 컬럼명 | snake_case | `member_id`, `created_at` |
+| 제약조건명 | PK_/FK_/UQ_/IDX_ 접두사 + snake_case | `PK_hotel_template`, `FK_order_member` |
+
+**컬럼명은 반드시 snake_case로 작성:**
+```typescript
+// ✅ 올바른 예
+await queryRunner.query(`ALTER TABLE tmp_order ADD COLUMN "member_id" integer NOT NULL`);
+
+// ❌ 잘못된 예 (camelCase 사용)
+await queryRunner.query(`ALTER TABLE tmp_order ADD COLUMN "memberId" integer NOT NULL`);
+```
+
+> TypeORM은 엔티티의 camelCase 프로퍼티를 자동으로 snake_case 컬럼명으로 변환합니다.
+> Migration에서 camelCase로 컬럼을 생성하면 엔티티와 매핑되지 않습니다.
+
 ## 금지 사항
 
 | 금지 | 이유 |
@@ -52,6 +72,7 @@ yarn migration:revert   # 되돌리기 (가장 최근 1개)
 | 수동으로 타임스탬프 생성 | 기존 migration과 순서 충돌 발생 |
 | 파일 직접 생성 | 타임스탬프 형식 오류 위험 |
 | 파일명 수동 수정 | 실행 순서 꼬임 발생 |
+| 컬럼명에 camelCase 사용 | TypeORM 엔티티 매핑 실패 |
 
 **왜 순서가 중요한가?**
 - TypeORM은 파일명의 타임스탬프 순서대로 migration 실행

--- a/apps/api/src/database/migration/1769947301856-AddMemberIdToTmpOrder.ts
+++ b/apps/api/src/database/migration/1769947301856-AddMemberIdToTmpOrder.ts
@@ -5,13 +5,13 @@ export class AddMemberIdToTmpOrder1769947301856 implements MigrationInterface {
     // 기존 tmp_order 데이터 삭제 (결제 전 임시 데이터이므로 삭제 가능)
     await queryRunner.query(`DELETE FROM tmp_order`);
 
-    // memberId 컬럼 추가 (NOT NULL)
+    // member_id 컬럼 추가 (NOT NULL)
     await queryRunner.query(
-      `ALTER TABLE tmp_order ADD COLUMN "memberId" integer NOT NULL`
+      `ALTER TABLE tmp_order ADD COLUMN "member_id" integer NOT NULL`
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE tmp_order DROP COLUMN "memberId"`);
+    await queryRunner.query(`ALTER TABLE tmp_order DROP COLUMN "member_id"`);
   }
 }


### PR DESCRIPTION
## Summary
- Migration의 컬럼명을 snake_case로 수정 (memberId → member_id)
- Migration 스킬 문서에 컬럼명 네이밍 규칙 추가

## Changes
- `AddMemberIdToTmpOrder` 마이그레이션: camelCase → snake_case
- `.claude/skills/Backend/migration.md`: 네이밍 규칙 섹션 추가

🤖 Generated with [Claude Code](https://claude.ai/code)