### PR TITLE
FEAT: 포트원 V2 결제 취소 API 연동

### DIFF
--- a/apps/api/src/module/shop/payment/shop.payment.service.ts
+++ b/apps/api/src/module/shop/payment/shop.payment.service.ts
@@ -272,4 +272,58 @@ export class ShopPaymentService {
     };
     this.logger.log('PortOne access token generated');
   }
+
+  /**
+   * PortOne 결제 취소 API 호출
+   * @param paymentId 결제 ID (orderNumber)
+   * @param reason 취소 사유
+   * @param amount 부분 취소 금액 (미지정 시 전액 취소)
+   * @returns 취소 결과
+   */
+  async cancelPayment(
+    paymentId: string,
+    reason: string,
+    amount?: number
+  ): Promise<{ success: boolean; cancellation?: Record<string, any> }> {
+    await this.generatePortoneAccessToken();
+
+    const requestBody: { reason: string; amount?: number } = { reason };
+    if (amount !== undefined) {
+      requestBody.amount = amount;
+    }
+
+    try {
+      const response = await axios.post(
+        `${this.PORTONE_API_URL}/payments/${paymentId}/cancel`,
+        requestBody,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.portoneToken.accessToken}`,
+          },
+        }
+      );
+
+      this.logger.log(
+        `Payment cancelled successfully: paymentId=${paymentId}, amount=${amount ?? '전액'}`
+      );
+
+      return {
+        success: true,
+        cancellation: response.data,
+      };
+    } catch (error: any) {
+      const errorType = error.response?.data?.type;
+      const errorMessage = error.response?.data?.message;
+
+      this.logger.error(
+        `Payment cancellation failed: paymentId=${paymentId}, type=${errorType}, message=${errorMessage}`,
+        error.stack
+      );
+
+      throw new BadRequestException(
+        errorMessage || '결제 취소에 실패했습니다.'
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- ShopPaymentService에 `cancelPayment` 메서드 추가
- 전액 취소 및 부분 취소 지원
- 기존 포트원 V2 인증 패턴 재사용

## 변경 사항
- `apps/api/src/module/shop/payment/shop.payment.service.ts`
  - `cancelPayment(paymentId, reason, amount?)` 메서드 추가

## 사용 방법
```typescript
// 전액 취소
await shopPaymentService.cancelPayment(paymentId, "고객 요청");

// 부분 취소
await shopPaymentService.cancelPayment(paymentId, "부분 환불", 12000);
```

## 다음 단계
- claim 모듈 머지 후 `approve()` 메서드에서 이 API 호출 연동

## Test plan
- [ ] 전액 취소 테스트
- [ ] 부분 취소 테스트
- [ ] 에러 케이스 검증

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)