### PR TITLE
FIX: 백오피스 주문 결제수단 실제 결제 방법으로 표시

### DIFF
--- a/apps/api/src/module/backoffice/order/order.service.ts
+++ b/apps/api/src/module/backoffice/order/order.service.ts
@@ -507,7 +507,7 @@ export class OrderService {
 
       // 결제 정보
       payment: {
-        paymentMethod: latestPayment?.pgProvider ?? '미결제',
+        paymentMethod: this.getPaymentMethod(latestPayment?.pgRawData),
         productAmount,
         refundAmount,
         totalAmount: productAmount - refundAmount,
@@ -520,6 +520,35 @@ export class OrderService {
         phone: order.customerPhone,
       },
     };
+  }
+
+  private getPaymentMethod(
+    pgRawData: Record<string, any> | null | undefined
+  ): string {
+    if (!pgRawData?.method) return '미결제';
+
+    const method = pgRawData.method;
+
+    if (method.provider) {
+      const easyPayMap: Record<string, string> = {
+        KAKAOPAY: '카카오페이',
+        NAVERPAY: '네이버페이',
+        TOSSPAY: '토스페이',
+        PAYCO: '페이코',
+        SAMSUNGPAY: '삼성페이',
+        APPLEPAY: '애플페이',
+      };
+      return easyPayMap[method.provider] ?? method.provider;
+    }
+
+    const methodTypeMap: Record<string, string> = {
+      PaymentMethodCard: '신용카드',
+      PaymentMethodVirtualAccount: '무통장입금',
+      PaymentMethodTransfer: '계좌이체',
+      PaymentMethodMobile: '휴대폰결제',
+      PaymentMethodEasyPay: '간편결제',
+    };
+    return methodTypeMap[method.type] ?? '카드결제';
   }
 
   /**
@@ -675,7 +704,9 @@ export class OrderService {
         productRefundAmount: refundAmount > 0 ? refundAmount : '-',
         totalRefundAmount: refundAmount > 0 ? refundAmount : '-',
         finalAmount: nowAmount,
-        paymentMethod: latestPayment?.pgProvider ?? '-',
+        paymentMethod: latestPayment?.pgRawData
+          ? this.getPaymentMethod(latestPayment.pgRawData)
+          : '-',
         requestNote: '-', // 스키마에 없음
         impUid: latestPayment?.impUid ?? '-',
         customerName: order.customerName,


### PR DESCRIPTION
## 📋 Summary

- 🐛 백오피스 주문 상세 및 엑셀에서 결제수단이 `pgProvider("portone")`로 표시되던 문제 수정
- ✨ `pgRawData.method`에서 실제 결제수단(카카오페이, 네이버페이, 신용카드 등)을 추출하여 표시

## 🔄 주요 변경사항

### 🖥️ Backend API

**파일:** `apps/api/src/module/backoffice/order/order.service.ts`

**변경 내용:**

1. **`getPaymentMethod()` 메서드 추가**
   - `pgRawData.method.provider`: 간편결제 제공자 매핑 (카카오페이, 네이버페이 등)
   - `pgRawData.method.type`: 결제 타입 매핑 (신용카드, 무통장입금, 계좌이체 등)

2. **적용 위치**
   - `findById()`: 주문 상세 조회
   - `exportToExcel()`: 주문 엑셀 다운로드

### 결제수단 매핑 테이블

| `method.provider` | 표시 |
|-------------------|------|
| KAKAOPAY | 카카오페이 |
| NAVERPAY | 네이버페이 |
| TOSSPAY | 토스페이 |
| PAYCO | 페이코 |
| SAMSUNGPAY | 삼성페이 |
| APPLEPAY | 애플페이 |

| `method.type` | 표시 |
|---------------|------|
| PaymentMethodCard | 신용카드 |
| PaymentMethodVirtualAccount | 무통장입금 |
| PaymentMethodTransfer | 계좌이체 |
| PaymentMethodMobile | 휴대폰결제 |
| PaymentMethodEasyPay | 간편결제 |

## 📁 변경된 파일

- `apps/api/src/module/backoffice/order/order.service.ts` - 결제수단 추출 로직 추가 및 적용

## 🎯 영향 범위

### ✅ 사이드이펙트 검토

- **백오피스 주문 상세**: 결제수단이 실제 결제 방법으로 표시됨
- **백오피스 주문 엑셀**: 결제수단 컬럼이 실제 결제 방법으로 표시됨
- **기존 주문 데이터**: `pgRawData` 필드를 참조하므로 기존 데이터에도 정상 적용

### ⚠️ Breaking Changes

- 없음 (내부 표시 로직만 변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)