### PR TITLE
FEAT: S3 파일 URL을 CDN URL로 변경

### DIFF
--- a/apps/api/config/default.js
+++ b/apps/api/config/default.js
@@ -87,6 +87,9 @@ module.exports = {
     s3: {
       bucket: 'yestravel-assets',
     },
+    cdn: {
+      baseUrl: 'https://cdn.yestravel.kr',
+    },
   },
   portone: {
     apiSecret: process.env.PORTONE_SECRET,

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -28,6 +28,9 @@ type AwsConfigType = {
   s3: {
     bucket: string;
   };
+  cdn: {
+    baseUrl: string;
+  };
 };
 
 type PortOneConfigType = {

--- a/apps/api/src/module/shared/aws/s3.service.ts
+++ b/apps/api/src/module/shared/aws/s3.service.ts
@@ -40,6 +40,7 @@ export class S3Service {
   private s3Client: S3Client;
   private readonly bucket: string;
   private readonly region: string;
+  private readonly cdnBaseUrl: string;
 
   constructor() {
     if (!ConfigProvider.aws) {
@@ -48,6 +49,7 @@ export class S3Service {
 
     this.region = ConfigProvider.aws.region;
     this.bucket = ConfigProvider.aws.s3.bucket;
+    this.cdnBaseUrl = ConfigProvider.aws.cdn.baseUrl;
 
     this.s3Client = new S3Client({
       region: this.region,
@@ -94,7 +96,7 @@ export class S3Service {
         expiresIn,
       });
 
-      const fileUrl = `https://${this.bucket}.s3.${this.region}.amazonaws.com/${key}`;
+      const fileUrl = `${this.cdnBaseUrl}/${key}`;
 
       return {
         uploadUrl,
@@ -126,7 +128,7 @@ export class S3Service {
   }
 
   getFileUrl(fileKey: string): string {
-    return `https://${this.bucket}.s3.${this.region}.amazonaws.com/${fileKey}`;
+    return `${this.cdnBaseUrl}/${fileKey}`;
   }
 
   /**
@@ -151,7 +153,7 @@ export class S3Service {
 
       await this.s3Client.send(command);
 
-      const fileUrl = `https://${this.bucket}.s3.${this.region}.amazonaws.com/${key}`;
+      const fileUrl = `${this.cdnBaseUrl}/${key}`;
 
       return {
         fileUrl,


### PR DESCRIPTION
## 📋 Summary

- ✨ S3 직접 URL 대신 CDN URL(`https://cdn.yestravel.kr`)로 파일을 제공하도록 변경
- 🐛 GitHub Issue #49 해결

## 🔄 주요 변경사항

### 🖥️ Backend API

**S3Service:**
- CDN Base URL 설정 추가 (`aws.cdn.baseUrl`)
- 파일 업로드/조회 시 S3 URL 대신 CDN URL 반환
- Presigned download URL은 기존대로 S3 직접 URL 사용 (보안 유지)

**변경된 메서드:**
- `generatePresignedUrl()` - 업로드 후 반환 URL
- `getFileUrl()` - 파일 조회 URL
- `uploadBuffer()` - 버퍼 업로드 후 반환 URL
- `generateDownloadUrl()` - **변경 없음** (presigned URL 필요)

## 📁 변경된 파일

- `apps/api/config/default.js` - CDN baseUrl 설정 추가
- `apps/api/src/config.ts` - `AwsConfigType`에 cdn 타입 추가
- `apps/api/src/module/shared/aws/s3.service.ts` - S3 URL을 CDN URL로 변경 (3곳)

## 🎯 영향 범위

### ✅ 사이드이펙트 검토

**긍정적 영향:**
- CDN 캐싱으로 파일 로딩 속도 향상
- 글로벌 엣지 서버를 통한 빠른 응답 시간
- S3 직접 트래픽 감소로 비용 절감

**영향받는 기능:**
- 이미지 업로드/조회하는 모든 기능 (캠페인 이미지, 호텔 이미지 등)
- 파일 다운로드 기능은 영향 없음 (presigned URL 유지)

### ⚠️ Breaking Changes

**없음** - API 응답 구조는 동일하며, URL만 변경됨

**주의사항:**
- CDN 설정이 올바르게 되어 있어야 함 (`cdn.yestravel.kr` → S3 버킷)
- 기존에 저장된 S3 URL은 영향 없음 (여전히 접근 가능)

## 🧪 테스트

- [ ] 이미지 업로드 후 CDN URL 반환 확인
- [ ] 반환된 CDN URL로 이미지 조회 가능 확인
- [ ] 파일 다운로드 presigned URL 정상 동작 확인

Closes #49

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>