### PR TITLE
FIX: Shop 토큰 무효 시 무한 재시도 루프 버그 수정

### DIFF
--- a/apps/shop/src/shared/trpc/providers.tsx
+++ b/apps/shop/src/shared/trpc/providers.tsx
@@ -4,7 +4,21 @@ import React from 'react';
 
 import { trpc, trpcClient } from './trpc';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: (failureCount, error: unknown) => {
+        // 인증 에러(UNAUTHORIZED)는 재시도하지 않음
+        const trpcError = error as { data?: { httpStatus?: number } };
+        if (trpcError?.data?.httpStatus === 401) return false;
+        return failureCount < 3;
+      },
+    },
+    mutations: {
+      retry: false,
+    },
+  },
+});
 
 export const TRPCProvider: React.FC<{ children: React.ReactNode }> = ({
   children,

--- a/apps/shop/src/shared/trpc/trpc.ts
+++ b/apps/shop/src/shared/trpc/trpc.ts
@@ -138,8 +138,12 @@ export const trpcClient = trpc.createClient({
             const newToken = useAuthStore.getState().accessToken;
             return makeRequest(newToken);
           }
+
+          // refresh 실패 + logout 완료: 토큰 없이 재요청 방지
+          return response;
         }
 
+        // 토큰 없이 401 받은 경우 (이미 logout 상태): 그대로 반환
         return response;
       },
     }),


### PR DESCRIPTION
## 설명

Shop에서 invalid token 에러 발생 시 React Query가 기본 retry 정책으로 계속 재요청하는 무한 루프 버그를 수정했습니다.

## 목표

인증 에러(401 UNAUTHORIZED) 발생 시 불필요한 재시도를 방지하여 무한 루프를 차단합니다.

## 변경사항

### 1. QueryClient retry 정책 추가
**파일:** `apps/shop/src/shared/trpc/providers.tsx`

**변경 내용:**
- QueryClient에 custom retry 로직 추가
- UNAUTHORIZED(401) 에러 발생 시 재시도 비활성화
- 일반 에러는 최대 3회까지 재시도
- Mutation은 재시도하지 않도록 설정

```typescript
const queryClient = new QueryClient({
  defaultOptions: {
    queries: {
      retry: (failureCount, error: unknown) => {
        const trpcError = error as { data?: { httpStatus?: number } };
        if (trpcError?.data?.httpStatus === 401) return false;
        return failureCount < 3;
      },
    },
    mutations: {
      retry: false,
    },
  },
});
```

### 2. refresh 실패 후 주석 보강
**파일:** `apps/shop/src/shared/trpc/trpc.ts`

**변경 내용:**
- refresh 실패 + logout 완료 시 토큰 없이 재요청 방지 로직 명확화
- 토큰 없이 401 받은 경우(이미 logout 상태) 처리 주석 추가

## 영향 범위

- Shop 앱의 인증 에러 처리
- React Query의 재시도 동작 (401 에러에만 영향)
- 사용자 경험 개선 (무한 로딩 방지)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>