### PR TITLE
FEAT: Context 자동 생성 트리거를 main push로 변경

### DIFF
--- a/.github/workflows/context-gen.yml
+++ b/.github/workflows/context-gen.yml
@@ -1,8 +1,9 @@
 name: Context Auto-Generation
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  push:
+    branches:
+      - main
     paths-ignore:
       - '.claude/context/**'
 
@@ -15,10 +16,10 @@ jobs:
   generate-context:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR branch
+      - name: Checkout main branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: main
           fetch-depth: 0
 
       - name: Read skill files
@@ -75,26 +76,42 @@ jobs:
             exit 0
           fi
 
-          CONTEXT_BRANCH="${{ github.head_ref }}-generated-context"
+          COMMIT_SHA="${{ github.sha }}"
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+          CONTEXT_BRANCH="context-gen-${SHORT_SHA}"
+
           git commit -m "docs: context 문서 자동 업데이트"
           git push --force origin HEAD:refs/heads/${CONTEXT_BRANCH}
 
+          # PR 제목 및 본문 생성
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          PR_TITLE="docs(context): Auto-generated context for ${SHORT_SHA}"
+          PR_BODY="$(cat <<PREOF
+          ## Auto-generated Context
+
+          This PR contains auto-generated context documents based on changes in commit ${SHORT_SHA}.
+
+          **Commit message:**
+          \`\`\`
+          ${COMMIT_MSG}
+          \`\`\`
+
+          **Related commit:** ${{ github.event.head_commit.url }}
+
+          ---
+
+          선택적으로 리뷰 후 머지하여 반영할 수 있습니다.
+          PREOF
+          )"
+
           # 기존 PR이 있으면 스킵, 없으면 생성
-          EXISTING_PR=$(gh pr list --head "${CONTEXT_BRANCH}" --base "${{ github.head_ref }}" --json number --jq '.[0].number')
+          EXISTING_PR=$(gh pr list --head "${CONTEXT_BRANCH}" --base "main" --json number --jq '.[0].number')
           if [ -z "$EXISTING_PR" ]; then
             gh pr create \
               --head "${CONTEXT_BRANCH}" \
-              --base "${{ github.head_ref }}" \
-              --title "docs: context 문서 자동 업데이트" \
-              --body "$(cat <<'PREOF'
-          ## Auto-generated Context
-
-          PR의 코드 변경을 분석하여 자동 생성된 context 문서입니다.
-          선택적으로 머지하여 반영할 수 있습니다.
-
-          > 이 PR은 re-sync 시 force push로 업데이트됩니다.
-          PREOF
-          )"
+              --base "main" \
+              --title "${PR_TITLE}" \
+              --body "${PR_BODY}"
           else
             echo "PR #${EXISTING_PR} already exists, force-pushed updates"
           fi


### PR DESCRIPTION
## 변경 사항

Context 자동 생성 워크플로우의 트리거를 변경하여, main 브랜치에 실제로 merge된 변경사항만 context로 문서화하도록 개선했습니다.

### 주요 변경

| 항목 | 변경 전 | 변경 후 |
|------|---------|---------|
| **트리거** | PR 생성/동기화 | main 브랜치 push |
| **브랜치 참조** | `github.head_ref` | `main` |
| **Context 브랜치명** | `{PR브랜치}-generated-context` | `context-gen-{commit_sha}` |
| **PR 제목** | PR 번호 참조 | commit SHA 참조 |
| **PR 본문** | PR 번호만 | commit SHA + 메시지 + URL |

### 변경 이유

**현재 방식의 문제:**
- PR 단계에서 context 생성 시, merge되지 않으면 불필요한 context 생성
- PR 리뷰 중 코드 변경 시 context도 함께 업데이트 필요

**변경 후 장점:**
- main에 실제로 merge된 변경사항만 context로 문서화
- 안정적인 코드베이스 기준으로 context 생성
- PR 리뷰 프로세스와 분리되어 더 명확한 워크플로우

### 무한 루프 방지

`paths-ignore: ['.claude/context/**']`로 context 문서 변경 시 워크플로우 미트리거를 보장합니다.

### 테스트 계획

- [ ] main에 코드 변경 push 시 워크플로우 자동 실행 확인
- [ ] context 문서 생성 및 별도 PR 정상 생성 확인
- [ ] context PR merge 후 워크플로우 미트리거 확인

## 관련 이슈

N/A

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>