### PR TITLE
FIX: ContactBar 이벤트 핸들러 타입 에러 수정

### DIFF
--- a/apps/shop/src/routes/promo/components/ContactBar.tsx
+++ b/apps/shop/src/routes/promo/components/ContactBar.tsx
@@ -42,13 +42,17 @@ export function ContactBar() {
               type="text"
               placeholder="브랜드/업체명"
               value={brandName}
-              onChange={e => setBrandName(e.target.value)}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setBrandName(e.target.value)
+              }
             />
             <ContactInput
               type="text"
               placeholder="연락처"
               value={contact}
-              onChange={e => setContact(e.target.value)}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setContact(e.target.value)
+              }
             />
             <ContactSubmitButton>무료 상담 신청</ContactSubmitButton>
           </ContactBarForm>
@@ -83,7 +87,7 @@ function ContactModal({
 
   return (
     <ModalOverlay onClick={onClose}>
-      <ModalCard onClick={e => e.stopPropagation()}>
+      <ModalCard onClick={(e: React.MouseEvent) => e.stopPropagation()}>
         <ModalTitle>제휴 문의</ModalTitle>
         <ModalDesc>문의 남겨주시면 인플루언서 리스트를 보내드립니다.</ModalDesc>
         <ModalFormGroup>
@@ -91,13 +95,17 @@ function ContactModal({
             type="text"
             placeholder="브랜드/업체명"
             value={brandName}
-            onChange={e => onBrandNameChange(e.target.value)}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              onBrandNameChange(e.target.value)
+            }
           />
           <ModalInput
             type="text"
             placeholder="연락처"
             value={contact}
-            onChange={e => onContactChange(e.target.value)}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              onContactChange(e.target.value)
+            }
           />
           <ModalSubmitButton>무료 상담 신청</ModalSubmitButton>
         </ModalFormGroup>


### PR DESCRIPTION
## 📋 Summary

Amplify 빌드가 TypeScript TS7006 에러로 실패하는 문제를 수정합니다. ContactBar 컴포넌트의 이벤트 핸들러에 타입을 추가하여 strict 모드에서도 정상 빌드되도록 개선했습니다.

## 🎯 Why (의도)

Amplify 빌드 시 TypeScript strict 모드에서 implicit any 타입 에러(TS7006)가 발생하여 배포가 실패하고 있었습니다.

## 🐛 What (문제)

ContactBar.tsx 파일의 이벤트 핸들러 `e` 파라미터에 타입이 명시되지 않아 다음과 같은 에러가 발생했습니다:
- `onChange` 핸들러: Parameter 'e' implicitly has an 'any' type
- `onClick` 핸들러: Parameter 'e' implicitly has an 'any' type

## 🔧 How (해결 방법)

모든 이벤트 핸들러에 적절한 React 이벤트 타입을 명시적으로 추가했습니다:
- `onChange`: `React.ChangeEvent<HTMLInputElement>` 타입 추가
- `onClick`: `React.MouseEvent` 타입 추가

## 🔄 주요 변경사항

### 변경 1: Desktop 폼 input onChange 타입 추가
**파일:** `apps/shop/src/routes/promo/components/ContactBar.tsx`
- 브랜드명 입력 필드 onChange 핸들러에 타입 추가
- 연락처 입력 필드 onChange 핸들러에 타입 추가

### 변경 2: Modal input onChange 타입 추가
**파일:** `apps/shop/src/routes/promo/components/ContactBar.tsx`
- 모달 브랜드명 입력 필드 onChange 핸들러에 타입 추가
- 모달 연락처 입력 필드 onChange 핸들러에 타입 추가

### 변경 3: Modal overlay onClick 타입 추가
**파일:** `apps/shop/src/routes/promo/components/ContactBar.tsx`
- 모달 카드 stopPropagation onClick 핸들러에 타입 추가

## ⚠️ 사이드 이펙트

| 영향 받는 영역 | 영향 내용 | 위험도 |
|---------------|----------|--------|
| 없음 | 타입만 추가, 런타임 로직 변경 없음 | 없음 |

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>