### PR TITLE
FormPageLayout width 스타일 버그 수정 (Tailwind JIT 동적 클래스 문제)

### DIFF
--- a/apps/backoffice/src/shared/components/layout/FormPageLayout.tsx
+++ b/apps/backoffice/src/shared/components/layout/FormPageLayout.tsx
@@ -50,18 +50,16 @@ const StyledContainer = tw.div`
 
 interface ContentProps {
   children: React.ReactNode;
-  /** 컨텐츠 너비 (기본: 860px) */
-  width?: string;
 }
 
-function Content({ children, width = '860px' }: ContentProps) {
-  return <StyledContent $width={width}>{children}</StyledContent>;
+function Content({ children }: ContentProps) {
+  return <StyledContent>{children}</StyledContent>;
 }
 
-const StyledContent = tw.div<{ $width: string }>`
+const StyledContent = tw.div`
   flex flex-col
   gap-8
-  ${({ $width }) => `w-[${$width}]`}
+  w-[860px]
 `;
 
 // ============================================


### PR DESCRIPTION
## 설명

`FormPageLayout`의 `StyledContent`에서 동적 Tailwind 클래스(`w-[${$width}]`)를 사용하면 Tailwind JIT 컴파일러가 빌드 시 해당 클래스를 감지하지 못해 width 스타일이 적용되지 않는 버그를 수정합니다.

## 목표

- Tailwind JIT가 정적으로 분석 가능한 클래스만 CSS로 생성한다는 원칙에 맞게, 동적 문자열 클래스를 정적 클래스로 교체
- `FormPageLayout.Content`의 width가 실제 화면에 정상 적용되도록 수정

## 변경사항

- [x] `StyledContent`의 동적 `$width` prop 제거
- [x] 템플릿 리터럴 방식(`w-[${$width}]`) → 정적 클래스(`w-[860px]`) 변경
- [x] `Content` 컴포넌트의 `width` prop 제거 (기본값 860px로 고정)

**파일:** `apps/backoffice/src/shared/components/layout/FormPageLayout.tsx`

```tsx
// Before
const StyledContent = tw.div<{ $width: string }>`
  flex flex-col
  gap-8
  ${({ $width }) => `w-[${$width}]`}
`;

// After
const StyledContent = tw.div`
  flex flex-col
  gap-8
  w-[860px]
`;
```

## 목표가 아닌 것 (생략 가능)

- 동적 width 지원: 현재 860px 외의 너비가 필요한 사용처가 없으므로 동적 기능은 제거. 추후 필요 시 Tailwind safelist 또는 인라인 스타일로 대응

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>