### PR TITLE
배포 서버에서 refreshToken API URL 하드코딩 문제 수정

### DIFF
--- a/apps/backoffice/src/store/authStore.ts
+++ b/apps/backoffice/src/store/authStore.ts
@@ -58,8 +58,10 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
 
   refreshToken: async () => {
     try {
+      const API_BASEURL =
+        import.meta.env.VITE_API_BASEURL || 'http://localhost:3000';
       const response = await fetch(
-        'http://localhost:3000/trpc/backofficeAuth.refresh',
+        `${API_BASEURL}/trpc/backofficeAuth.refresh`,
         {
           method: 'POST',
           credentials: 'include',


### PR DESCRIPTION
## 설명

배포 서버(`backoffice.dev.yestravel.co.kr`)에서 인플루언서 목록 페이지의 "수정" 버튼 클릭 시 로그인 페이지로 리다이렉트되는 버그를 수정합니다.

`authStore.ts`의 `refreshToken()` 함수에서 API URL이 `http://localhost:3000`으로 하드코딩되어 있어 배포 서버에서 토큰 갱신에 실패하고 로그아웃 처리되던 문제를 환경변수(`VITE_API_BASEURL`)를 사용하도록 변경하여 해결합니다.

## 목표

- `authStore.ts`의 `refreshToken()`이 배포 서버에서도 올바른 API 서버로 토큰 갱신 요청을 보내도록 수정
- `trpc.ts`의 `refreshAccessToken()`과 동일한 방식으로 환경변수를 사용하도록 통일

## 변경사항

- [x] `apps/backoffice/src/store/authStore.ts`: `refreshToken()` 내 하드코딩된 `http://localhost:3000`을 `import.meta.env.VITE_API_BASEURL || 'http://localhost:3000'`으로 변경

## 목표가 아닌 것 (생략 가능)

- `trpc.ts`의 `refreshAccessToken()` 수정 - 이미 올바르게 환경변수를 사용 중
- 다른 페이지의 인증 관련 로직 변경

---

## 🐛 버그 상세 (Why / What / How)

**Why (의도):** 배포 서버에서도 인증 토큰 갱신이 정상 동작해야 합니다.

**What (문제):** `authStore.ts`의 `refreshToken()`이 `http://localhost:3000`으로 하드코딩되어 있어, 배포 환경에서 토큰 갱신 요청이 실패하고 `logout()`이 호출되어 사용자가 강제 로그아웃됩니다.

**How (해결 방법):** `VITE_API_BASEURL` 환경변수를 읽어 API 베이스 URL을 동적으로 결정하도록 수정합니다. fallback으로 `http://localhost:3000`을 유지하여 로컬 개발 환경 호환성을 보장합니다.

## 🔀 변경 흐름

```mermaid
graph LR
  A[사용자 액션 - 수정 버튼 클릭] --> B[authStore.refreshToken]
  B --> C{API URL}
  C -->|기존: 하드코딩| D[http://localhost:3000 - 배포서버에서 실패]
  C -->|수정: 환경변수| E[VITE_API_BASEURL - 배포서버에서 성공]
  E --> F[토큰 갱신 성공 - 페이지 정상 접근]
  D --> G[logout - 로그인 페이지 리다이렉트]
```

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>