### PR TITLE
인플루언서 수정 페이지 ReadonlyMode 소셜미디어 섹션 표시 버그 수정

### DIFF
--- a/apps/backoffice/src/routes/_auth/influencer/_components/InfluencerForm.tsx
+++ b/apps/backoffice/src/routes/_auth/influencer/_components/InfluencerForm.tsx
@@ -84,6 +84,10 @@ export function InfluencerForm({
     { value: 'OTHER', label: '기타' },
   ];
 
+  const getPlatformLabel = (value: string) => {
+    return platformOptions.find((opt) => opt.value === value)?.label ?? value;
+  };
+
   const handleFormSubmit = async (formData: CreateInfluencerInput) => {
     if (!onSubmit) return;
 
@@ -245,7 +249,7 @@ export function InfluencerForm({
             <SectionHeader>
               <SectionTitleWithRequired>
                 <SectionTitle>소셜미디어</SectionTitle>
-                <RequiredBadge>*</RequiredBadge>
+                {isEditMode && <RequiredBadge>*</RequiredBadge>}
               </SectionTitleWithRequired>
               {isEditMode && (
                 <AddButton type="button" onClick={handleAddSocialMedia}>
@@ -255,42 +259,61 @@ export function InfluencerForm({
               )}
             </SectionHeader>
 
-            {socialMediaError && isEditMode && (
-              <ErrorMessage>{socialMediaError}</ErrorMessage>
-            )}
+            {isEditMode ? (
+              <>
+                {socialMediaError && (
+                  <ErrorMessage>{socialMediaError}</ErrorMessage>
+                )}
 
-            {fields.length === 0 && !isEditMode && (
-              <EmptyMessage>등록된 소셜미디어가 없습니다.</EmptyMessage>
+                <SocialMediaList>
+                  {fields.map((field, index) => (
+                    <SocialMediaItem key={field.id}>
+                      <SocialMediaFields>
+                        <PlatformSelect>
+                          <Select
+                            {...register(
+                              `socialMedias.${index}.platform` as const,
+                            )}
+                            options={platformOptions}
+                          />
+                        </PlatformSelect>
+                        <UrlInput>
+                          <Input
+                            {...register(`socialMedias.${index}.url` as const, {
+                              required: 'URL을 입력하세요',
+                            })}
+                            placeholder="https://..."
+                          />
+                        </UrlInput>
+                        <RemoveButton
+                          type="button"
+                          onClick={() => remove(index)}
+                        >
+                          <X size={16} />
+                        </RemoveButton>
+                      </SocialMediaFields>
+                    </SocialMediaItem>
+                  ))}
+                </SocialMediaList>
+              </>
+            ) : (
+              <>
+                {!data?.socialMedias || data.socialMedias.length === 0 ? (
+                  <EmptyMessage>등록된 소셜미디어가 없습니다.</EmptyMessage>
+                ) : (
+                  <ReadonlySocialMediaList>
+                    {data.socialMedias.map((media, index) => (
+                      <ReadonlySocialMediaItem key={index}>
+                        <ReadonlyPlatformLabel>
+                          {getPlatformLabel(media.platform)}
+                        </ReadonlyPlatformLabel>
+                        <ReadonlyUrlValue>{media.url}</ReadonlyUrlValue>
+                      </ReadonlySocialMediaItem>
+                    ))}
+                  </ReadonlySocialMediaList>
+                )}
+              </>
             )}
-
-            <SocialMediaList>
-              {fields.map((field, index) => (
-                <SocialMediaItem key={field.id}>
-                  <SocialMediaFields>
-                    <PlatformSelect>
-                      <Select
-                        {...register(`socialMedias.${index}.platform` as const)}
-                        options={platformOptions}
-                        disabled={!isEditMode}
-                      />
-                    </PlatformSelect>
-                    <UrlInput>
-                      <Input
-                        {...register(`socialMedias.${index}.url` as const, {
-                          required: 'URL을 입력하세요',
-                        })}
-                        placeholder="https://..."
-                      />
-                    </UrlInput>
-                    {isEditMode && (
-                      <RemoveButton type="button" onClick={() => remove(index)}>
-                        <X size={16} />
-                      </RemoveButton>
-                    )}
-                  </SocialMediaFields>
-                </SocialMediaItem>
-              ))}
-            </SocialMediaList>
           </Section>
 
           {/* 사업자 정보 */}
@@ -600,6 +623,29 @@ const EmptyMessage = tw.div`
   text-sm
   text-gray-500
   py-4
+`;
+
+const ReadonlySocialMediaList = tw.div`
+  space-y-3
+`;
+
+const ReadonlySocialMediaItem = tw.div`
+  flex
+  items-baseline
+  gap-4
+`;
+
+const ReadonlyPlatformLabel = tw.dt`
+  text-sm
+  font-medium
+  text-gray-500
+  w-24
+  shrink-0
+`;
+
+const ReadonlyUrlValue = tw.dd`
+  text-sm
+  text-gray-900
 `;
 
 const ButtonGroup = tw.div`


### PR DESCRIPTION
## Summary

인플루언서 수정 페이지에서 ReadonlyMode일 때 소셜미디어 섹션이 Select/Input 폼 형태로 잘못 표시되던 문제를 수정합니다. 다른 섹션(기본정보, 사업자, 정산)과 동일하게 텍스트 형태로 표시하도록 변경합니다.

## 주요 변경사항

### ReadonlyMode 소셜미디어 섹션 텍스트 표시 처리

**파일:** `apps/backoffice/src/routes/_auth/influencer/_components/InfluencerForm.tsx`

- ReadonlyMode 여부에 따라 소셜미디어 섹션을 분기 처리
  - ReadonlyMode: 플랫폼명 + URL을 텍스트로 표시
  - EditMode: 기존 Select/Input 폼 형태 유지
- `getPlatformLabel` 헬퍼 함수 추가: 플랫폼 enum 값을 한글 레이블로 변환
- Readonly 전용 styled-components 추가
  - `ReadonlySocialMediaList`: 소셜미디어 목록 컨테이너
  - `ReadonlySocialMediaItem`: 개별 소셜미디어 항목 레이아웃
  - `ReadonlyPlatformLabel`: 플랫폼명 텍스트 스타일
  - `ReadonlyUrlValue`: URL 텍스트 스타일

## 사이드 이펙트

| 영향 받는 영역 | 영향 내용 | 위험도 |
|---------------|----------|--------|
| 인플루언서 수정 페이지 - ReadonlyMode | 소셜미디어 섹션 표시 방식 변경 (폼 → 텍스트) | 낮음 |
| 인플루언서 수정 페이지 - EditMode | 변경 없음 | 없음 |

## 변경 흐름

```mermaid
graph LR
  A[InfluencerForm] --> B{isReadonly?}
  B -->|Yes| C[ReadonlySocialMediaList\n플랫폼명 + URL 텍스트]
  B -->|No| D[기존 Select/Input 폼]
```

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>