### PR TITLE
숙박 상품 취소 수수료 카드 UI 추가

### DIFF
--- a/apps/backoffice/src/routes/_auth/product/_components/create/CancellationFeeCard.tsx
+++ b/apps/backoffice/src/routes/_auth/product/_components/create/CancellationFeeCard.tsx
@@ -1,0 +1,132 @@
+/**
+ * CancellationFeeCard - 취소 수수료 설정 카드
+ *
+ * 숙박 상품의 취소 수수료 정책을 입력하는 컴포넌트입니다.
+ * 체크인 N일 전 취소 시 부과되는 수수료 퍼센트를 설정합니다.
+ */
+
+import {
+  Button,
+  Table,
+  THead,
+  TBody,
+  TR,
+  TH,
+  TD,
+} from '@yestravelkr/min-design-system';
+import { Plus } from 'lucide-react';
+import { useFormContext } from 'react-hook-form';
+import tw from 'tailwind-styled-components';
+
+import { FormCard } from '@/shared/components/form/FormLayout';
+
+interface CancellationFee {
+  daysBeforeCheckIn: number;
+  feePercentage: number;
+}
+
+export function CancellationFeeCard() {
+  const { watch, setValue } = useFormContext();
+  const cancellationFees =
+    (watch('cancellationFees') as CancellationFee[]) || [];
+
+  const handleAdd = () => {
+    const newFees = [
+      ...cancellationFees,
+      { daysBeforeCheckIn: 0, feePercentage: 0 },
+    ];
+    setValue('cancellationFees', newFees);
+  };
+
+  const handleRemove = (index: number) => {
+    const newFees = cancellationFees.filter((_, i) => i !== index);
+    setValue('cancellationFees', newFees);
+  };
+
+  const handleUpdate = (
+    index: number,
+    field: keyof CancellationFee,
+    value: number,
+  ) => {
+    const newFees = [...cancellationFees];
+    newFees[index] = { ...newFees[index], [field]: value };
+    setValue('cancellationFees', newFees);
+  };
+
+  return (
+    <FormCard title="취소 수수료">
+      <Table>
+        <THead>
+          <TR>
+            <TH style={{ width: 120 }}>취소일</TH>
+            <TH style={{ width: 120 }}>수수료</TH>
+            <TH />
+          </TR>
+        </THead>
+        <TBody>
+          {cancellationFees.map((fee, index) => (
+            <TR key={index}>
+              <TD.Input
+                type="number"
+                placeholder="0"
+                value={fee.daysBeforeCheckIn || ''}
+                onChange={(e) =>
+                  handleUpdate(
+                    index,
+                    'daysBeforeCheckIn',
+                    Number(e.target.value),
+                  )
+                }
+                min={0}
+                postfix="일 전"
+              />
+              <TD.Input
+                type="number"
+                placeholder="0"
+                value={fee.feePercentage || ''}
+                onChange={(e) =>
+                  handleUpdate(index, 'feePercentage', Number(e.target.value))
+                }
+                min={0}
+                max={100}
+                postfix="%"
+              />
+              <TD>
+                <div className="flex justify-end">
+                  <Button
+                    kind="critical"
+                    variant="outline"
+                    shape="soft"
+                    size="small"
+                    onClick={() => handleRemove(index)}
+                  >
+                    삭제
+                  </Button>
+                </div>
+              </TD>
+            </TR>
+          ))}
+        </TBody>
+      </Table>
+
+      <AddButton type="button" onClick={handleAdd}>
+        <Plus size={16} />
+        수수료 추가
+      </AddButton>
+    </FormCard>
+  );
+}
+
+/**
+ * Usage:
+ *
+ * <FormProvider {...methods}>
+ *   <CancellationFeeCard />
+ * </FormProvider>
+ */
+
+// Styled Components
+
+const AddButton = tw.button`
+  flex items-center gap-1 mt-4 text-sm text-gray-500 hover:text-gray-700
+`;

--- a/apps/backoffice/src/routes/_auth/product/_components/create/ProductForm.tsx
+++ b/apps/backoffice/src/routes/_auth/product/_components/create/ProductForm.tsx
@@ -20,6 +20,7 @@ import {
   RightColumn,
 } from '../../../product-template/_components/create/styled';
 
+import { CancellationFeeCard } from './CancellationFeeCard';
 import { ProductOptionsPricingCard } from './ProductOptionsPricingCard';
 
 interface ProductFormData {
@@ -47,6 +48,10 @@ interface ProductFormData {
   hotelSkus: Array<{
     checkInDate: string;
     quantity: number;
+  }>;
+  cancellationFees: Array<{
+    daysBeforeCheckIn: number;
+    feePercentage: number;
   }>;
 }
 
@@ -108,6 +113,7 @@ export function ProductForm({
                 watch={watch}
               />
               <ProductOptionsPricingCard />
+              <CancellationFeeCard />
             </LeftColumn>
 
             <RightColumn>

--- a/apps/backoffice/src/routes/_auth/product/hotel.$productId.edit.tsx
+++ b/apps/backoffice/src/routes/_auth/product/hotel.$productId.edit.tsx
@@ -46,6 +46,10 @@ interface ProductFormData {
     checkInDate: string;
     quantity: number;
   }>;
+  cancellationFees: Array<{
+    daysBeforeCheckIn: number;
+    feePercentage: number;
+  }>;
 }
 
 function EditProductPage() {
@@ -85,6 +89,7 @@ function EditProductPage() {
       thumbnailUrls: [],
       hotelOptions: [],
       hotelSkus: [],
+      cancellationFees: [],
     },
   });
 
@@ -107,6 +112,7 @@ function EditProductPage() {
         thumbnailUrls: product.thumbnailUrls,
         hotelOptions: product.hotelOptions || [],
         hotelSkus: product.hotelSkus || [],
+        cancellationFees: (product as any).cancellationFees || [],
       });
       setThumbnails(product.thumbnailUrls);
     }

--- a/apps/backoffice/src/routes/_auth/product/hotel.create.tsx
+++ b/apps/backoffice/src/routes/_auth/product/hotel.create.tsx
@@ -47,6 +47,10 @@ interface ProductFormData {
     checkInDate: string;
     quantity: number;
   }>;
+  cancellationFees: Array<{
+    daysBeforeCheckIn: number;
+    feePercentage: number;
+  }>;
 }
 
 function CreateProductPage() {
@@ -79,6 +83,7 @@ function CreateProductPage() {
       thumbnailUrls: [],
       hotelOptions: [],
       hotelSkus: [],
+      cancellationFees: [],
     },
   });
 


### PR DESCRIPTION
## 설명

백오피스 숙박 상품 생성/수정 폼에 취소 수수료 설정 카드 UI를 추가합니다.
백엔드 연동은 별도로 진행하며, 이번 PR은 UI 구현에만 집중합니다.

## 목표

- 숙박 상품 취소 수수료 설정을 위한 CancellationFeeCard 컴포넌트 구현
- 호텔 생성/수정 폼에 취소 수수료 카드 배치

## 변경사항

- [x] `CancellationFeeCard.tsx` 신규 컴포넌트 생성 — 취소 수수료 항목 추가/삭제/입력 UI
- [x] `ProductForm.tsx` — CancellationFeeCard 배치 및 cancellationFees 타입 추가
- [x] `hotel.create.tsx` — defaultValues에 cancellationFees 필드 추가
- [x] `hotel.$productId.edit.tsx` — defaultValues에 cancellationFees 필드 추가

## 목표가 아닌 것

- 백엔드 API 연동 (별도 PR로 진행 예정)
- tRPC mutation에 cancellationFees 필드 전송

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>