### PR TITLE
호텔 상품 취소 수수료 백엔드 구현

### DIFF
--- a/apps/api/src/database/migration/1773138129971-add-cancellation-fees.ts
+++ b/apps/api/src/database/migration/1773138129971-add-cancellation-fees.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCancellationFees1773138129971 implements MigrationInterface {
+  name = 'AddCancellationFees1773138129971';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // product 테이블에 cancellation_fees jsonb 컬럼 추가
+    await queryRunner.query(
+      `ALTER TABLE "product" ADD "cancellation_fees" jsonb DEFAULT '[]'`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // cancellation_fees 컬럼 삭제
+    await queryRunner.query(
+      `ALTER TABLE "product" DROP COLUMN "cancellation_fees"`
+    );
+  }
+}

--- a/apps/api/src/module/backoffice/domain/product/hotel-product.entity.ts
+++ b/apps/api/src/module/backoffice/domain/product/hotel-product.entity.ts
@@ -4,6 +4,7 @@ import { ProductTypeEnum } from '@src/module/backoffice/admin/admin.schema';
 import { TransactionService } from '@src/module/shared/transaction/transaction.service';
 import { getEntityManager } from '@src/database/datasources';
 import type { Nullish } from '@src/types/utility.type';
+import type { HotelCancelPolicyItem } from '@src/module/backoffice/domain/order/claim-detail.type';
 
 export interface CreateHotelProductInput {
   name: string;
@@ -23,6 +24,7 @@ export interface CreateHotelProductInput {
   checkOutTime: string;
   bedTypes?: string[];
   tags?: string[];
+  cancellationFees?: HotelCancelPolicyItem[];
 }
 
 export interface UpdateHotelProductInput extends CreateHotelProductInput {
@@ -67,6 +69,10 @@ export class HotelProductEntity extends ProductEntity {
   @Column('jsonb', { default: [], nullable: true })
   tags: Nullish<string[]>;
 
+  // 취소 수수료 정책 (리스트)
+  @Column('jsonb', { default: [], nullable: true })
+  cancellationFees: Nullish<HotelCancelPolicyItem[]>;
+
   // 헬퍼 메서드: Entity 생성
   static createFromInput(input: CreateHotelProductInput): HotelProductEntity {
     const product = new HotelProductEntity();
@@ -87,6 +93,7 @@ export class HotelProductEntity extends ProductEntity {
     product.checkOutTime = input.checkOutTime;
     product.bedTypes = input.bedTypes || [];
     product.tags = input.tags || [];
+    product.cancellationFees = input.cancellationFees || [];
     return product;
   }
 
@@ -109,6 +116,7 @@ export class HotelProductEntity extends ProductEntity {
     this.checkOutTime = input.checkOutTime;
     this.bedTypes = input.bedTypes || [];
     this.tags = input.tags || [];
+    this.cancellationFees = input.cancellationFees || [];
   }
 }
 

--- a/apps/api/src/module/backoffice/product/product.router.ts
+++ b/apps/api/src/module/backoffice/product/product.router.ts
@@ -119,6 +119,12 @@ export class ProductRouter extends BaseTrpcRouter {
         checkOutTime: z.string(),
         bedTypes: z.array(z.string()),
         tags: z.array(z.string()),
+        cancellationFees: z.array(
+          z.object({
+            daysBeforeCheckIn: z.number(),
+            feePercentage: z.number(),
+          })
+        ),
         hotelOptions: z.array(
           z.object({
             id: z.number(),
@@ -234,6 +240,14 @@ export class ProductRouter extends BaseTrpcRouter {
           .transform(normalizeTime),
         bedTypes: z.array(z.string()).default([]),
         tags: z.array(z.string()).default([]),
+        cancellationFees: z
+          .array(
+            z.object({
+              daysBeforeCheckIn: z.number().int().min(0),
+              feePercentage: z.number().min(0).max(100),
+            })
+          )
+          .default([]),
         hotelOptions: z
           .array(
             z.object({
@@ -358,6 +372,14 @@ export class ProductRouter extends BaseTrpcRouter {
           .transform(normalizeTime),
         bedTypes: z.array(z.string()).default([]),
         tags: z.array(z.string()).default([]),
+        cancellationFees: z
+          .array(
+            z.object({
+              daysBeforeCheckIn: z.number().int().min(0),
+              feePercentage: z.number().min(0).max(100),
+            })
+          )
+          .default([]),
         hotelOptions: z
           .array(
             z.object({

--- a/apps/api/src/module/backoffice/product/product.schema.ts
+++ b/apps/api/src/module/backoffice/product/product.schema.ts
@@ -76,6 +76,14 @@ const hotelProductInputSchema = baseProductInputSchema.extend({
     .transform(normalizeTime),
   bedTypes: z.array(z.string()).default([]),
   tags: z.array(z.string()).default([]),
+  cancellationFees: z
+    .array(
+      z.object({
+        daysBeforeCheckIn: z.number().int().min(0),
+        feePercentage: z.number().min(0).max(100),
+      })
+    )
+    .default([]),
   hotelOptions: z.array(hotelOptionInputSchema).default([]),
   hotelSkus: z.array(hotelSkuInputSchema).default([]),
 });
@@ -170,6 +178,12 @@ const hotelProductSchema = z.object({
   checkOutTime: z.string(),
   bedTypes: z.array(z.string()),
   tags: z.array(z.string()),
+  cancellationFees: z.array(
+    z.object({
+      daysBeforeCheckIn: z.number(),
+      feePercentage: z.number(),
+    })
+  ),
   hotelOptions: z.array(hotelOptionResponseSchema),
   hotelSkus: z.array(
     z.object({

--- a/apps/api/src/module/backoffice/product/product.service.ts
+++ b/apps/api/src/module/backoffice/product/product.service.ts
@@ -109,6 +109,7 @@ export class ProductService {
           checkOutTime: hotel.checkOutTime ?? '11:00:00',
           bedTypes: hotel.bedTypes ?? [],
           tags: hotel.tags ?? [],
+          cancellationFees: hotel.cancellationFees ?? [],
           hotelOptions: hotelOptions.map(opt => ({
             id: opt.id,
             name: opt.name,

--- a/packages/api-types/src/server.ts
+++ b/packages/api-types/src/server.ts
@@ -1103,6 +1103,12 @@ const appRouter = t.router({
         checkOutTime: z.string(),
         bedTypes: z.array(z.string()),
         tags: z.array(z.string()),
+        cancellationFees: z.array(
+          z.object({
+            daysBeforeCheckIn: z.number(),
+            feePercentage: z.number(),
+          })
+        ),
         hotelOptions: z.array(
           z.object({
             id: z.number(),
@@ -1218,6 +1224,14 @@ const appRouter = t.router({
           .transform(normalizeTime),
         bedTypes: z.array(z.string()).default([]),
         tags: z.array(z.string()).default([]),
+        cancellationFees: z
+          .array(
+            z.object({
+              daysBeforeCheckIn: z.number().int().min(0),
+              feePercentage: z.number().min(0).max(100),
+            })
+          )
+          .default([]),
         hotelOptions: z
           .array(
             z.object({
@@ -1344,6 +1358,14 @@ const appRouter = t.router({
           .transform(normalizeTime),
         bedTypes: z.array(z.string()).default([]),
         tags: z.array(z.string()).default([]),
+        cancellationFees: z
+          .array(
+            z.object({
+              daysBeforeCheckIn: z.number().int().min(0),
+              feePercentage: z.number().min(0).max(100),
+            })
+          )
+          .default([]),
         hotelOptions: z
           .array(
             z.object({


### PR DESCRIPTION
## Summary

호텔 상품에 취소 수수료 정책(cancellationFees) 데이터를 저장하고 조회할 수 있도록 백엔드를 구현합니다.
프론트엔드 UI는 별도 PR(#300)로 완료되었으며, 이 PR은 해당 UI와 연동되는 백엔드 처리를 담당합니다.

## Why (의도)

프론트엔드(#300)에서 취소 수수료 카드 UI가 완성되었으나, 실제 데이터를 DB에 저장하고 불러오는 백엔드 처리가 없었습니다.
호텔 상품 생성/수정 시 취소 수수료 정책을 함께 저장하고 조회할 수 있어야 합니다.

## What (문제)

- HotelProductEntity에 cancellationFees 컬럼이 없어 취소 수수료 데이터 저장 불가
- product.schema.ts / product.router.ts의 Zod 스키마에 cancellationFees 필드 누락
- product.service.ts의 findById 응답에 cancellationFees 미포함
- DB에 cancellation_fees 컬럼이 없어 마이그레이션 필요

## How (해결 방법)

- `HotelProductEntity`에 `cancellationFees` jsonb 컬럼 추가, 기존 `HotelCancelPolicyItem` 타입 재사용
- `product.schema.ts`의 input/response Zod 스키마에 `cancellationFees` 필드 추가
- `product.router.ts`의 create/update 인라인 스키마에 `cancellationFees` 추가
- `product.service.ts` `findById`에서 `cancellationFees ?? []` 기본값 처리
- `packages/api-types/src/server.ts` tRPC 타입 동기화
- DB 마이그레이션 파일 추가: `cancellation_fees jsonb` 컬럼

## 주요 변경사항

### 변경 1: Entity 컬럼 추가
**파일:** `apps/api/src/module/backoffice/domain/product/hotel-product.entity.ts`
- `@Column('jsonb', { default: [], nullable: true })` 로 cancellationFees 컬럼 추가
- `HotelCancelPolicyItem` 타입 재사용 (기존 주문 도메인 타입)
- createFromInput, updateFromInput 메서드에 cancellationFees 반영

### 변경 2: Zod 스키마 추가
**파일:** `apps/api/src/module/backoffice/product/product.schema.ts`
- input 스키마: `daysBeforeCheckIn`, `feePercentage` 유효성 검증 포함
- response 스키마: 조회 응답에 cancellationFees 포함

### 변경 3: Router 인라인 스키마 추가
**파일:** `apps/api/src/module/backoffice/product/product.router.ts`
- getById 응답 스키마, createHotel/updateHotel 입력 스키마에 모두 추가

### 변경 4: Service 기본값 처리
**파일:** `apps/api/src/module/backoffice/product/product.service.ts`
- findById 응답 매핑에서 `cancellationFees: hotel.cancellationFees ?? []` 추가

### 변경 5: Migration 추가
**파일:** `apps/api/src/database/migration/1773138129971-add-cancellation-fees.ts`
- product 테이블에 `cancellation_fees jsonb` 컬럼 추가
- 기본값 `'[]'` 설정

## 사이드 이펙트

| 영향 받는 영역 | 영향 내용 | 위험도 |
|---------------|----------|--------|
| 기존 호텔 상품 | cancellation_fees 컬럼 기본값 [] 이므로 영향 없음 | 낮음 |
| 프론트엔드 #300 | 이 PR 머지 후 UI와 정상 연동 가능 | 낮음 |

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>