### PR TITLE
FEAT: Shop 배포를 Amplify에서 GitHub Actions + S3 + CloudFront로 전환

### DIFF
--- a/.github/workflows/deploy-shop.yml
+++ b/.github/workflows/deploy-shop.yml
@@ -1,0 +1,139 @@
+name: Deploy Shop
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/shop/**'
+      - 'packages/**'
+
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Action to perform'
+        required: true
+        type: choice
+        options:
+          - deploy-prod
+      commit_hash:
+        description: 'Commit hash to deploy to production (from build-prod/)'
+        required: true
+        type: string
+
+env:
+  S3_BUCKET: yestravel-shop
+  NODE_VERSION: 22.16.x
+
+jobs:
+  # ──────────────────────────────────────────────
+  # Job 1: main push → dev 배포 + prod 빌드 저장
+  # ──────────────────────────────────────────────
+  build-and-deploy-dev:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache yarn dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      # ── Dev 빌드 & 배포 ──
+      - name: Build Shop (dev)
+        working-directory: apps/shop
+        env:
+          VITE_API_BASEURL: https://api.dev.yestravel.co.kr
+          VITE_API_URL: https://api.dev.yestravel.co.kr/trpc
+        run: yarn build
+
+      - name: Deploy to S3 (development/)
+        run: |
+          aws s3 sync apps/shop/dist s3://$S3_BUCKET/development/ --delete
+
+      - name: Invalidate CloudFront (dev)
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.SHOP_CF_DEV_DISTRIBUTION_ID }} \
+            --paths "/*"
+
+      # ── Prod 빌드 & 저장 ──
+      - name: Build Shop (prod)
+        working-directory: apps/shop
+        env:
+          VITE_API_BASEURL: https://api.yestravel.co.kr
+          VITE_API_URL: https://api.yestravel.co.kr/trpc
+        run: |
+          rm -rf dist
+          yarn build
+
+      - name: Save prod build to S3 (build-prod/{hash}/)
+        run: |
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          aws s3 sync apps/shop/dist s3://$S3_BUCKET/build-prod/$COMMIT_HASH/ --delete
+          echo "✅ Prod build saved to s3://$S3_BUCKET/build-prod/$COMMIT_HASH/"
+          echo "📋 To deploy to production, run workflow_dispatch with commit_hash: $COMMIT_HASH"
+
+  # ──────────────────────────────────────────────
+  # Job 2: 수동 버튼 → prod 배포
+  # ──────────────────────────────────────────────
+  deploy-prod:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy-prod'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Verify build exists
+        run: |
+          HASH="${{ github.event.inputs.commit_hash }}"
+          if ! aws s3 ls s3://$S3_BUCKET/build-prod/$HASH/ > /dev/null 2>&1; then
+            echo "❌ Build not found: s3://$S3_BUCKET/build-prod/$HASH/"
+            echo "Available builds:"
+            aws s3 ls s3://$S3_BUCKET/build-prod/ --recursive | head -20
+            exit 1
+          fi
+          echo "✅ Build found: s3://$S3_BUCKET/build-prod/$HASH/"
+
+      - name: Deploy to production
+        run: |
+          HASH="${{ github.event.inputs.commit_hash }}"
+          aws s3 sync s3://$S3_BUCKET/build-prod/$HASH/ s3://$S3_BUCKET/production/ --delete
+          echo "✅ Deployed build-prod/$HASH → production/"
+
+      - name: Invalidate CloudFront (prod)
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.SHOP_CF_PROD_DISTRIBUTION_ID }} \
+            --paths "/*"
+          echo "✅ CloudFront cache invalidated"


### PR DESCRIPTION
## Summary
- Amplify 자동배포 대신 GitHub Actions 배포 파이프라인 구성
- S3 버킷(`yestravel-shop`) + CloudFront(dev/prod) 인프라 생성 완료
- main push 시 dev 자동 배포 + prod 빌드 저장, 수동 버튼으로 prod 배포

## 배포 구조
```
yestravel-shop/           # S3 버킷
├── development/           # main push → 자동 배포
├── build-prod/{hash}/     # main push → prod 빌드 저장
└── production/            # workflow_dispatch → 수동 배포
```

## CloudFront
- Dev: `d15kufr8akynms.cloudfront.net` (E2KAQAJ0LLB2BZ)
- Prod: `d24xqe4l3a66zc.cloudfront.net` (E2V7Y5SR17VEZ1)

## GitHub Secrets 추가 완료
- `SHOP_CF_DEV_DISTRIBUTION_ID`
- `SHOP_CF_PROD_DISTRIBUTION_ID`

## 후속 작업
- [ ] 머지 후 첫 배포 테스트
- [ ] DNS 전환 (도메인 → 새 CloudFront)
- [ ] Amplify 해제
- [ ] Backoffice도 동일 구조로 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)