### PR TITLE
REFACTOR: jun-claude-code 0.6.4 Skills 업데이트

### DIFF
--- a/.claude/.jun-installed.json
+++ b/.claude/.jun-installed.json
@@ -1,0 +1,144 @@
+{
+  "version": "0.6.4",
+  "installedAt": "2026-03-23T01:12:54.367Z",
+  "files": {
+    "CLAUDE.md": {
+      "hash": "58c7de4e212e77ce6a2287a9af061a22e070e4fd87312b511f93ffcbd84a7e73"
+    },
+    "hooks/dangerous-command-blocker.sh": {
+      "hash": "d98aa04f0c42cbc74858401640463b7fdd6d4e0fdffe830e49e62c20ce22638c"
+    },
+    "hooks/session-wrap-suggester.sh": {
+      "hash": "3a70420f088e4b270e99c51289ce66495e8e77d6b37529506e680940899948b3"
+    },
+    "hooks/skill-forced.sh": {
+      "hash": "992acecde104535c4239dc1d366fe26277a4fa07788962e0ab6f4063a5c4bc57"
+    },
+    "hooks/workflow-enforced.sh": {
+      "hash": "98fe67cdd9c53bc151ba4547c37f2f12aaa6964b7365fbc3bf7ec38c7cae8e52"
+    },
+    "agents/architect.md": {
+      "hash": "c8eb647baa6f746f64bfb25d3b9160aef5d1ee046d02de29ab4a2344fe2b4deb"
+    },
+    "agents/automation-scout.md": {
+      "hash": "8c19d17a5e09c6040870a8279355412f90045876949d06322ed1746dc13ec974"
+    },
+    "agents/code-reviewer.md": {
+      "hash": "f7d33ae6a9ca89a74c436ce207b2e776726980742b1b20dffe6dab77e77da27a"
+    },
+    "agents/code-writer.md": {
+      "hash": "d5769f586f130f2549018939d4ce63a7c7371a72866a10dfa9d7da5641027fac"
+    },
+    "agents/context-collector.md": {
+      "hash": "bff41d2a4d7e5caf1c647f6bd2b10e2a4fdc1c796f171389f7ee81038bfaa5ae"
+    },
+    "agents/context-manager.md": {
+      "hash": "9f3388e2372532e30534fda4296ae0097cb208fa73522f0fb24050c1892e6942"
+    },
+    "agents/designer.md": {
+      "hash": "3d31d51fc57653528ea90bc7596601ecd4216ec097b436b899c806df89128466"
+    },
+    "agents/director.md": {
+      "hash": "24e78d6ce0e1690e9f4259686c2f997180b726705eab189ddf9cfd2f7bb2ffe0"
+    },
+    "agents/explore.md": {
+      "hash": "b8f4462b4c5b8c40e0ed9463b46b2244df1cf25ba5c9f0b4709e72a39f28e095"
+    },
+    "agents/followup-suggester.md": {
+      "hash": "e36836a914d9c1175da8449c4a5d1dc2848295eb6f8d001a74e15b8f50c26cdf"
+    },
+    "agents/git-manager.md": {
+      "hash": "ff913cb3b41f2a517728594680e4b1eb48d9ef5d91110969219f2440503315fb"
+    },
+    "agents/impact-analyzer.md": {
+      "hash": "20b10d93eda4c5f2e606212f733335146ac7f33fe4eb7ccf27c5fa6d717b6eea"
+    },
+    "agents/learning-extractor.md": {
+      "hash": "729e33ed9e953dfd9a52f62288770375d41db41948eb63913f11fba3719f3c7e"
+    },
+    "agents/plan-verifier.md": {
+      "hash": "961b1cdf0e7b2c3f125dd4cc13a6704096603d64902f297ee36cf98e815fe3b6"
+    },
+    "agents/qa-tester.md": {
+      "hash": "9bbe44e6c064c8f40f339224e9fb32257a7eeac11ef6853f5f143d5e37ddf804"
+    },
+    "agents/simple-code-writer.md": {
+      "hash": "90c450e70cfc74d3f9530cb86b9cc03586226af9bde5cdae11e8ba61edf17699"
+    },
+    "agents/task-enricher.md": {
+      "hash": "1df9109f9e07ad7d97f5e03126b896ff854d605738416aabc85825c125b52d13"
+    },
+    "agents/task-planner.md": {
+      "hash": "293966c5c9b9a0462ced392a44701163e8f45cbb6c146465cdf655f26fd1d814"
+    },
+    "skills/Backend/SKILL.md": {
+      "hash": "6793bfcbce188b0e6b7b274a7bab8989b89560a0d0905152e8dd03cf01d7db1a"
+    },
+    "skills/Backend/bdd-testing.md": {
+      "hash": "90ef513e4a0d16c65e344553544e9df5b77a24037e18c30182bb0cdb9e14d285"
+    },
+    "skills/Coding/SKILL.md": {
+      "hash": "097661a300ad275aac98364684d712b1def4bfc4a3eb3966ef6d72450418f406"
+    },
+    "skills/ContextHandoff/SKILL.md": {
+      "hash": "0673bad145f5ba055e9c6db3dd05d43cdd13fd6d28a59cff6c73dd2ad15da1f0"
+    },
+    "skills/Director/SKILL.md": {
+      "hash": "45408c1b7964a1ab68fbfb59cb8e4037ab808b22d25695d7780066dea128c653"
+    },
+    "skills/Documentation/SKILL.md": {
+      "hash": "9db407965cfb7d218748512c81f13d68b0f03b4440c8b4331f3fa50a2dbd7663"
+    },
+    "skills/Git/SKILL.md": {
+      "hash": "e6142eb24fb5e5a685f83dcf3055870a9e6b27805b1b2086ec9ab76bf2947d1b"
+    },
+    "skills/Git/git.md": {
+      "hash": "916bd107d9c1dfa54ea2bac1e6aab7f698dae07ed104c91a24ef4dafc782efb7"
+    },
+    "skills/Git/pr-apply.md": {
+      "hash": "4bbb692f5d59b0ef803a2bd60d25816d84c0eb49d69a73ce07e1ce899c373756"
+    },
+    "skills/Git/pr-review.md": {
+      "hash": "80b40205a8fb94ccab2644be2cbd75a0560c1ea2723ae258f615a7304c624516"
+    },
+    "skills/Planning/SKILL.md": {
+      "hash": "12361516785d2f3a6c06028557c8637ce038911bdcf37b69d5c210d70d6b6e67"
+    },
+    "skills/PromptStructuring/SKILL.md": {
+      "hash": "1c7553efd1be9543592f4cd0476578883081f4e3fdf2e7f5b649459ab4d59394"
+    },
+    "skills/PromptStructuring/output-optimization.md": {
+      "hash": "71085cb9d07d5a7202ebfcce4d8116afb3a2971c03dc7f03c660c2eb431b23c3"
+    },
+    "skills/PromptStructuring/positive-phrasing.md": {
+      "hash": "2039e7c00ec4094e9c19993663028671deaea83077ade7e1690eac9331ff455e"
+    },
+    "skills/PromptStructuring/skills-frontmatter.md": {
+      "hash": "14dfa1e392257517640a76a8808a725a67adb56c2b4ba386a4018b2560ba6e7b"
+    },
+    "skills/PromptStructuring/xml-tags.md": {
+      "hash": "e470f72bb51102ab5a0ecf510982c6fd99e1073f1857e63f76fedb1516ec373f"
+    },
+    "skills/React/SKILL.md": {
+      "hash": "9d5ac2d88891bf3337dbf33227462a3af67458874e8532baa6d596464f9bb5ac"
+    },
+    "skills/React/react-hook-form.md": {
+      "hash": "a711259e7bf93f8263d15af6a5fb8766e9c0a931fd9c6654f0605677575f9e57"
+    },
+    "skills/React/tailwind-styled.md": {
+      "hash": "d0094b7267770c156f56d5e8b35be285ba6b27a8e86387baf88480f4037f51af"
+    },
+    "skills/React/tanstack-router.md": {
+      "hash": "3bb31b4e6b40b0432ec166e272edf83a6db4a9c9a5f7f69b28103089981098de"
+    },
+    "skills/Reporting/SKILL.md": {
+      "hash": "7b85508ffeeffa6bed50f9624526d8811225af0ad9bbbb344f97ec02c060e2df"
+    },
+    "skills/SessionWrap/SKILL.md": {
+      "hash": "38a344b145dbe129ab70dbc4735431c97f92f34e5d2ec8d382e80e61a6db8178"
+    },
+    "skills/TypeORM/SKILL.md": {
+      "hash": "99c7a656a27db5fcb32d64a14e02a2d7ff9d98a8c05e6d97d8b52e412393bbad"
+    }
+  }
+}

--- a/.claude/skills/Backend/SKILL.md
+++ b/.claude/skills/Backend/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: Backend
-description: NestJS/TypeORM 백엔드 개발 시 사용. 레이어 객체 변환, find vs queryBuilder 선택 기준, BDD 테스트 작성 규칙 제공.
-keywords: [Backend, 백엔드, 레이어, DTO, Entity, Service, Controller, TypeORM, find, queryBuilder, test, BDD, 테스트, Jest]
+description: NestJS 백엔드 개발 시 사용. 레이어 객체 변환 규칙, BDD 테스트 작성 규칙 제공.
+keywords: [Backend, 백엔드, 레이어, DTO, Entity, Service, Controller, test, BDD, 테스트, Jest]
 user-invocable: false
 ---
 
@@ -90,92 +90,6 @@ async findOne(@Param('id') id: number) {
 
 ---
 
-<rules>
-
-## TypeORM 사용 규칙
-
-> **find 메서드를 기본으로 사용하고, QueryBuilder는 필요한 경우에만 사용한다.**
-
-### find 메서드 우선 사용
-
-```typescript
-// ✅ 기본 조회
-const user = await this.userRepository.findOneBy({ id });
-const users = await this.userRepository.find({
-  where: { status: 'active' },
-  relations: ['orders'],
-  order: { createdAt: 'DESC' },
-  take: 10,
-});
-
-// ✅ 조건 조합
-const users = await this.userRepository.find({
-  where: [
-    { status: 'active', role: 'admin' },
-    { status: 'active', role: 'manager' },
-  ],
-});
-```
-
-### QueryBuilder 허용 케이스
-
-**다음 경우에만 QueryBuilder 사용:**
-
-| 케이스 | 예시 |
-|--------|------|
-| **groupBy** | 집계 쿼리 |
-| **getRawMany/getRawOne** | 원시 데이터 필요 |
-| **복잡한 서브쿼리** | 중첩 쿼리 |
-| **복잡한 JOIN 조건** | ON 절 커스텀 |
-
-</rules>
-
-<examples>
-<example type="good">
-```typescript
-// ✅ QueryBuilder 허용: groupBy + getRawMany
-const stats = await this.orderRepository
-  .createQueryBuilder('order')
-  .select('order.status', 'status')
-  .addSelect('COUNT(*)', 'count')
-  .addSelect('SUM(order.amount)', 'total')
-  .groupBy('order.status')
-  .getRawMany();
-```
-</example>
-<example type="bad">
-```typescript
-// ❌ 불필요한 QueryBuilder 사용
-const user = await this.userRepository
-  .createQueryBuilder('user')
-  .where('user.id = :id', { id })
-  .getOne();
-```
-</example>
-<example type="good">
-```typescript
-// ✅ find로 대체
-const user = await this.userRepository.findOneBy({ id });
-```
-</example>
-</examples>
-
----
-
-<rules>
-
-## 자동 생성 파일
-
-> **자동 생성되는 파일은 직접 수정하지 않는다.**
-
-| 파일 | 생성 방식 | 규칙 |
-|------|----------|------|
-| `packages/api-types/src/server.ts` | tRPC 라우터 기반 자동 생성 | 직접 수정 금지, generate 후 결과만 커밋 |
-
-</rules>
-
----
-
 <checklist>
 
 ## 체크리스트
@@ -184,9 +98,6 @@ const user = await this.userRepository.findOneBy({ id });
 - [ ] Service에서 Entity가 필요한 시점에 변환하는가?
 - [ ] Service의 return은 Entity 또는 일반 객체인가?
 - [ ] Controller에서 Response DTO/Schema로 변환하는가?
-- [ ] TypeORM find 메서드를 우선 사용하는가?
-- [ ] QueryBuilder는 groupBy, getRawMany 등 필요한 경우에만 사용하는가?
-- [ ] `packages/api-types/src/server.ts`를 직접 수정하지 않았는가? (자동 생성 파일)
 
 </checklist>
 
@@ -196,6 +107,7 @@ const user = await this.userRepository.findOneBy({ id });
 
 | 주제 | 위치 | 설명 |
 |-----|------|------|
+| TypeORM 사용 규칙 | `TypeORM/SKILL.md` | find vs queryBuilder 선택 기준 |
 | BDD 테스트 | `bdd-testing.md` | NestJS + Jest BDD 스타일 테스트 작성 규칙 |
 
 </reference>

--- a/.claude/skills/Coding/SKILL.md
+++ b/.claude/skills/Coding/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: Coding
-description: 모든 코드 작성 시 참조. SRP/결합도/응집도 판단 기준, 폴더 구조 설계 원칙, 삼항연산자/try-catch 가독성 규칙, Plan 필수 항목(DB/FE Flow/API + 의사결정 근거) 제공.
-keywords: [SRP, 단일책임, 결합도, 응집도, 설계원칙, 폴더구조, 아키텍처, 가독성, 삼항연산자, try-catch, Plan, DB설계, FE Flow, API구성, 의사결정]
+description: 모든 코드 작성 시 참조. SRP/결합도/응집도 판단 기준, 폴더 구조 설계 원칙, 삼항연산자/try-catch 가독성 규칙 제공.
+keywords: [SRP, 단일책임, 결합도, 응집도, 설계원칙, 폴더구조, 아키텍처, 가독성, 삼항연산자, try-catch]
 user-invocable: false
 ---
 
@@ -209,55 +209,6 @@ if (isAdmin) {
 
 ---
 
-<rules>
-
-## Plan 작성 필수 항목
-
-> **코드 수정 계획(Plan)에는 아래 3가지 설계와 의사결정 근거를 포함한다.**
-
-### 필수 설계 항목
-
-| 항목 | 포함 내용 | 예시 |
-|------|----------|------|
-| **DB 수정 계획** | Entity 변경, 컬럼 추가/삭제, 마이그레이션, 인덱스 | 새 Entity 생성, 기존 테이블 컬럼 추가, FK 관계 설정 |
-| **FE 페이지 Flow** | 화면 흐름, 사용자 동선, 상태 전이, 라우트 구조 | 리스트 → 상세 → 수정 페이지 흐름, 모달/토스트 트리거 |
-| **API 구성** | 엔드포인트 목록, 요청/응답 구조, tRPC 프로시저 | `product.findAll`, `product.create` 등 프로시저 정의 |
-
-### 의사결정 근거
-
-각 설계 항목에 아래를 명시한다:
-
-| 항목 | 설명 |
-|------|------|
-| **선택한 이유** | 왜 이 방식을 선택했는가 (성능, 확장성, 기존 패턴 일관성 등) |
-| **차선책** | 검토했으나 채택하지 않은 대안과 그 이유 |
-
-<examples>
-<example type="good">
-```markdown
-## DB 수정 계획
-- ProductOption Entity 신규 생성 (Product와 1:N 관계)
-- 이유: 옵션 개수가 가변적이므로 별도 테이블 분리
-- 차선책: Product에 JSON 컬럼으로 저장 → 쿼리/필터링 어려워 기각
-
-## FE 페이지 Flow
-- 상품 목록 → 상품 상세 → 옵션 선택 → 장바구니
-- 이유: 기존 호텔 예약 Flow와 동일한 패턴 유지
-- 차선책: 목록에서 바로 옵션 선택 → UX 복잡도 증가로 기각
-
-## API 구성
-- product.findAll: 목록 조회 (pagination)
-- product.findOne: 상세 + 옵션 포함
-- 이유: findOne에서 옵션을 join으로 한 번에 조회 (N+1 방지)
-- 차선책: 옵션을 별도 API로 분리 → 프론트 호출 2번 필요해 기각
-```
-</example>
-</examples>
-
-</rules>
-
----
-
 <checklist>
 
 ## 코드 작성 시 체크리스트
@@ -269,7 +220,5 @@ if (isAdmin) {
 - [ ] 공개 API(index.ts)를 통해 접근하는가?
 - [ ] Promise 처리에 then-catch 패턴을 사용했는가?
 - [ ] 삼항연산자에서 복잡한 함수 호출을 변수로 분리했는가?
-- [ ] Plan에 DB 수정 계획 / FE 페이지 Flow / API 구성이 포함되었는가?
-- [ ] 각 설계 항목에 선택 이유와 차선책이 명시되었는가?
 
 </checklist>

--- a/.claude/skills/TypeORM/SKILL.md
+++ b/.claude/skills/TypeORM/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: TypeORM
+description: TypeORM 사용 시 참조. find > queryBuilder > rawQuery 우선순위, 가독성 기반 선택 기준, Migration 생성 규칙 제공.
+keywords: [TypeORM, find, queryBuilder, rawQuery, Repository, 쿼리, ORM, migration]
+user-invocable: false
+---
+
+# TypeORM 사용 규칙
+
+<rules>
+
+## 쿼리 작성 우선순위
+
+> **가독성을 최우선으로, find > QueryBuilder > Raw Query 순서로 사용한다.**
+
+| 우선순위 | 방식 | 사용 조건 |
+|---------|------|----------|
+| 1 | **find 메서드** | 기본 CRUD, 단순 조건, relations |
+| 2 | **QueryBuilder** | groupBy, 집계, 커스텀 JOIN — 가독성이 유지되는 경우 |
+| 3 | **Raw Query** | QueryBuilder의 서브쿼리 등으로 가독성이 떨어지는 경우 |
+
+### 핵심 판단 기준: 가독성
+
+QueryBuilder가 허용되는 케이스라도, 서브쿼리 중첩 등으로 **코드 가독성이 떨어지면 Raw Query를 사용한다.**
+
+## find 메서드 (우선순위 1)
+
+```typescript
+// ✅ 기본 조회
+const user = await this.userRepository.findOneBy({ id });
+const users = await this.userRepository.find({
+  where: { status: 'active' },
+  relations: ['orders'],
+  order: { createdAt: 'DESC' },
+  take: 10,
+});
+
+// ✅ 조건 조합
+const users = await this.userRepository.find({
+  where: [
+    { status: 'active', role: 'admin' },
+    { status: 'active', role: 'manager' },
+  ],
+});
+```
+
+## QueryBuilder (우선순위 2)
+
+**다음 경우에 QueryBuilder 사용 (가독성이 유지될 때):**
+
+| 케이스 | 예시 |
+|--------|------|
+| **groupBy** | 집계 쿼리 |
+| **getRawMany/getRawOne** | 원시 데이터 필요 |
+| **커스텀 JOIN 조건** | ON 절 커스텀 |
+| **단순 서브쿼리** | 가독성이 유지되는 서브쿼리 |
+
+## Raw Query (우선순위 3)
+
+**QueryBuilder로 작성 시 가독성이 떨어지는 경우 Raw Query 사용:**
+
+| 케이스 | 이유 |
+|--------|------|
+| **복잡한 서브쿼리 중첩** | QueryBuilder 체이닝이 읽기 어려움 |
+| **복잡한 CTE (WITH 절)** | QueryBuilder로 표현 시 과도한 중첩 |
+| **DB 특화 문법** | QueryBuilder가 지원하지 않는 문법 |
+
+</rules>
+
+<examples>
+
+### find vs QueryBuilder
+
+<example type="bad">
+```typescript
+// ❌ 불필요한 QueryBuilder 사용
+const user = await this.userRepository
+  .createQueryBuilder('user')
+  .where('user.id = :id', { id })
+  .getOne();
+```
+</example>
+<example type="good">
+```typescript
+// ✅ find로 대체
+const user = await this.userRepository.findOneBy({ id });
+```
+</example>
+
+### QueryBuilder 허용
+
+<example type="good">
+```typescript
+// ✅ QueryBuilder 허용: groupBy + getRawMany (가독성 유지)
+const stats = await this.orderRepository
+  .createQueryBuilder('order')
+  .select('order.status', 'status')
+  .addSelect('COUNT(*)', 'count')
+  .addSelect('SUM(order.amount)', 'total')
+  .groupBy('order.status')
+  .getRawMany();
+```
+</example>
+
+### QueryBuilder → Raw Query 전환
+
+<example type="bad">
+```typescript
+// ❌ 서브쿼리 중첩으로 가독성 저하
+const result = await this.orderRepository
+  .createQueryBuilder('order')
+  .where((qb) => {
+    const subQuery = qb
+      .subQuery()
+      .select('oi.orderId')
+      .from(OrderItem, 'oi')
+      .where((qb2) => {
+        const subQuery2 = qb2
+          .subQuery()
+          .select('p.id')
+          .from(Product, 'p')
+          .where('p.category = :cat', { cat: 'electronics' })
+          .getQuery();
+        return 'oi.productId IN ' + subQuery2;
+      })
+      .getQuery();
+    return 'order.id IN ' + subQuery;
+  })
+  .getMany();
+```
+</example>
+<example type="good">
+```typescript
+// ✅ Raw Query로 가독성 확보
+const result = await this.orderRepository.query(
+  `SELECT o.*
+   FROM orders o
+   WHERE o.id IN (
+     SELECT oi.order_id
+     FROM order_items oi
+     WHERE oi.product_id IN (
+       SELECT p.id FROM products p WHERE p.category = $1
+     )
+   )`,
+  ['electronics'],
+);
+```
+</example>
+
+</examples>
+
+<rules>
+
+## Migration 생성 규칙
+
+> **Migration 파일은 직접 생성하지 않고, `yarn migration:create` 명령어로 생성한 뒤 수정한다.**
+
+### 이유
+
+직접 파일을 생성하면 타임스탬프 충돌이 발생할 수 있다. CLI 명령어를 통해 생성해야 TypeORM이 타임스탬프를 자동 관리한다.
+
+### 생성 방법
+
+```bash
+# package.json에 migration:create가 정의된 경우
+yarn migration:create src/migrations/MigrationName
+
+# 정의되지 않은 경우 직접 실행
+yarn run typeorm migration:create src/migrations/MigrationName
+```
+
+### 작업 순서
+
+1. `yarn migration:create`로 빈 migration 파일 생성
+2. 생성된 파일의 `up()` / `down()` 메서드 작성
+3. `yarn migration:run`으로 적용 확인
+
+</rules>
+
+<checklist>
+
+## 체크리스트
+
+- [ ] find 메서드를 우선 사용하는가?
+- [ ] QueryBuilder는 find로 불가능한 경우에만 사용하는가?
+- [ ] QueryBuilder 서브쿼리 중첩으로 가독성이 떨어지면 Raw Query로 전환했는가?
+- [ ] Migration 파일을 `yarn migration:create`로 생성했는가? (직접 파일 생성 금지)
+
+</checklist>


### PR DESCRIPTION
## Summary

- TypeORM 규칙을 `Backend/SKILL.md`에서 독립 Skill(`TypeORM/SKILL.md`)로 분리
- Plan 작성 규칙을 `Coding/SKILL.md`에서 `Planning` Skill로 분리하여 구조 개선
- `jun-claude-code@0.6.4` 업데이트 메타데이터(`.jun-installed.json`) 추가

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `.claude/skills/Backend/SKILL.md` | TypeORM 섹션 제거, TypeORM Skill 참조로 대체 |
| `.claude/skills/Coding/SKILL.md` | Plan 작성 규칙 제거, Planning Skill 참조로 대체 |
| `.claude/skills/TypeORM/SKILL.md` | TypeORM 전용 Skill 신규 추가 |
| `.claude/.jun-installed.json` | v0.6.4 설치 메타데이터 추가 |

## Test plan

- [ ] Backend Skill에서 TypeORM 관련 작업 시 `TypeORM/SKILL.md`가 정상 참조되는지 확인
- [ ] Coding Skill에서 Plan 작성 시 `Planning/SKILL.md`가 정상 참조되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)