### PR TITLE
FIX: 호텔 주문 저장 시 checkInDate/checkOutDate가 null로 저장되는 버그 수정

### DIFF
--- a/apps/api/src/module/shop/payment/shop.payment.service.ts
+++ b/apps/api/src/module/shop/payment/shop.payment.service.ts
@@ -99,9 +99,13 @@ export class ShopPaymentService {
     // order.id는 이미 from() 메서드에서 설정됨
     order.status = OrderStatusEnum.PAID;
 
-    // 4. Order 저장
+    // 4. Order 저장 (호텔은 HotelOrderRepository로 저장해야 checkInDate/checkOutDate 컬럼이 반영됨)
     const savedOrder =
-      await this.repositoryProvider.OrderRepository.save(order);
+      tmpOrder.type === ProductTypeEnum.HOTEL
+        ? await this.repositoryProvider.HotelOrderRepository.save(
+            order as HotelOrderEntity
+          )
+        : await this.repositoryProvider.OrderRepository.save(order);
 
     // 5. TmpOrder 삭제 (더 이상 필요 없음)
     await this.repositoryProvider.TmpOrderRepository.delete({


### PR DESCRIPTION
## 문제 원인

TypeORM은 `Repository.save()` 호출 시, **Repository의 target entity 메타데이터**를 기준으로 INSERT/UPDATE 컬럼 목록을 결정합니다.

`OrderRepository`의 target은 `OrderEntity`이므로, `HotelOrderEntity`를 `OrderRepository.save()`로 저장하면 `HotelOrderEntity`에만 존재하는 컬럼(`checkInDate`, `checkOutDate`)이 메타데이터에 포함되지 않아 **null로 저장**되는 버그가 발생했습니다.

## 수정 내용

- `apps/api/src/module/shop/payment/shop.payment.service.ts`
- 호텔 주문 저장 시 `OrderRepository.save()` 대신 `HotelOrderRepository.save()`를 사용하도록 분기 추가
- `HotelOrderRepository`의 target은 `HotelOrderEntity`이므로 `checkInDate`, `checkOutDate` 컬럼이 정상적으로 INSERT됨

## 테스트

- [ ] 호텔 주문 생성 후 `checkInDate`, `checkOutDate`가 DB에 정상 저장되는지 확인

Closes #332